### PR TITLE
uses `Util_Malloc()` for allocating Vector**

### DIFF
--- a/src/test/util/test.cpp
+++ b/src/test/util/test.cpp
@@ -87,8 +87,8 @@ void tutil4 (void)
 
 void tutil5 (void)
 {
-	Vector *vectors[] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 	size_t const numel = 8;
+	Vector **vectors = (Vector**) Util_Malloc(numel * sizeof(Vector*));
 	for (size_t i = 0; i != numel; ++i) {
 		vectors[i] = new Vector();
 		if (!vectors[i]) {


### PR DESCRIPTION
COMMENTS:
rather use this than the array initializer
valgrind reports no memory issues