### PR TITLE
adds uniform random number generator

### DIFF
--- a/include/GFORTRAN.h
+++ b/include/GFORTRAN.h
@@ -1,44 +1,20 @@
-#include "util.h"
-#include "Random.h"
-#include "GFORTRAN.h"
+#ifndef GUARD_BDX_GFORTRAN_H
+#define GUARD_BDX_GFORTRAN_H
 
-Random::Random ()
-{
-	return;
-}
+#define frandom_number(x) _gfortran_random_r8
+#define fanint(x) _gfortran_specific__anint_r8
 
-Random::Random (enum random kind) : _kind_(kind)
-{
-	return;
-}
+extern "C" void _gfortran_random_r8(double*);
+extern "C" double _gfortran_specific__anint_r8(double*);
 
-double Random::fetch () const
-{
-	double x = 0;
-	enum random kind = this->_kind_;
-	if (kind == random::UNIFORM) {
-		frandom_number(&x);
-		return x;
-	} else {
-		return x;	// TODO: implement Gaussian PRNG
-	}
-}
-
-void *Random::operator new (size_t size)
-{
-	return Util_Malloc(size);
-}
-
-void Random::operator delete (void *p)
-{
-	p = Util_Free(p);
-}
+#endif
 
 /*
 
 BDX                                             December 31, 2023
 
 Copyright (C) 2023 Misael Díaz-Maldonado
+Copyright (C) 2024 UCF-Research Group
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -53,7 +29,7 @@ You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 author: @misael-diaz
-source: src/random/Random.cpp
+source: include/GFORTRAN.h
 
 References:
 [0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.

--- a/include/Random.h
+++ b/include/Random.h
@@ -1,9 +1,17 @@
 #ifndef GUARD_BDX_RANDOM_H
 #define GUARD_BDX_RANDOM_H
 
+enum random {
+	UNIFORM,
+	NORMAL
+};
+
 struct Random
 {
+	enum random _kind_ = random::UNIFORM;
 	Random();
+	Random(enum random);
+	double fetch() const;
 	void *operator new(size_t size);
 	void operator delete(void *p);
 };


### PR DESCRIPTION
NOTES:
forwards the task of generating uniformly distributed pseudo-random numbers to GNU Fortran's `random_number()` intrinsic.

So this feat makes the code non-portable but it is not an issue for us since the HPC clusters run GNU/Linux and we use open-source toolchains. I am sure that anyone wishing to use Intel Fortran compiler will be able to modify the source code accordingly.