### PR TITLE
implements normally distributed PRNG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ include make-inc
 
 export CXX
 export CXXOPT
+export LIBS
 
 all: srcs
 

--- a/include/GFORTRAN.h
+++ b/include/GFORTRAN.h
@@ -1,8 +1,8 @@
 #ifndef GUARD_BDX_GFORTRAN_H
 #define GUARD_BDX_GFORTRAN_H
 
-#define frandom_number(x) _gfortran_random_r8
-#define fanint(x) _gfortran_specific__anint_r8
+#define frandom_number(x) _gfortran_random_r8(x)
+#define fanint(x) _gfortran_specific__anint_r8(x)
 
 extern "C" void _gfortran_random_r8(double*);
 extern "C" double _gfortran_specific__anint_r8(double*);

--- a/make-inc
+++ b/make-inc
@@ -15,3 +15,4 @@
 
 CXX = g++-10
 CXXOPT = -DGXX=1 -DDEBUG=1 -std=gnu++11 -g -Wall -Wextra -Wformat -O0
+LIBS = -lgfortran

--- a/src/random/Random.cpp
+++ b/src/random/Random.cpp
@@ -1,6 +1,36 @@
+#include <cmath>
 #include "util.h"
 #include "Random.h"
 #include "GFORTRAN.h"
+
+static double uniform ()
+{
+	double u = 0;
+	frandom_number(&u);
+	return u;
+}
+
+static double normal ()
+{
+	double x1, x2, x3;
+	double r = x1 = x2 = x3 = 0;
+	while (r == 0 || r > 1.0) {
+
+		frandom_number(&x1);
+		frandom_number(&x2);
+
+		x1 = 2.0 * x1 - 1.0;
+		x2 = 2.0 * x2 - 1.0;
+
+		r = x1 * x1 + x2 * x2;
+	}
+
+	x2 = 1.0 / r;
+	x3 = -2.0 * log(r);
+	r = sqrt(x2 * x3);
+	double n = (x1 * r);
+	return n;
+}
 
 Random::Random ()
 {
@@ -14,13 +44,11 @@ Random::Random (enum random kind) : _kind_(kind)
 
 double Random::fetch () const
 {
-	double x = 0;
 	enum random kind = this->_kind_;
 	if (kind == random::UNIFORM) {
-		frandom_number(&x);
-		return x;
+		return uniform();
 	} else {
-		return x;	// TODO: implement Gaussian PRNG
+		return normal();
 	}
 }
 

--- a/src/test/util/Makefile
+++ b/src/test/util/Makefile
@@ -19,7 +19,7 @@ include make-inc
 all: $(TEST_BIN)
 
 $(TEST_BIN): $(TEST_OBJ)
-	$(CXX) $(CXXOPT) $(OBJS) -o $(TEST_BIN)
+	$(CXX) $(CXXOPT) $(OBJS) -o $(TEST_BIN) $(LIBS)
 
 $(TEST_OBJ): $(HEADERS) $(TEST_CXX)
 	$(CXX) $(INC) $(CXXOPT) -c $(TEST_CXX) -o $(TEST_OBJ)


### PR DESCRIPTION
NOTES:
Implements Böx-Muller's transformation to obtain normally (or Gaussian) pseudo-random numbers from uniformly distributed pseudo random numbers.

fixes compilation error from previous commit (seems that the comitted GFORTRAN.h header was altered unintentionally)

fixes linking error by linking against libgfortran

still need to check the statistics of the PRNGs as mentioned in issue #36