### PR TITLE
adds file handler util

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -3,10 +3,13 @@
 
 #include <cstddef>
 
+void  Util_Clear(void);
 void *Util_Free(void *p);
-void *Util_Clear(void);
 void *Util_Malloc(size_t const sz);
 char *Util_CopyString(const char *string);
+void *Util_OpenFile(const char *filename, const char *mode);
+void *Util_CloseFile(void* vfile);
+void  Util_CloseFiles(void);
 
 #endif
 

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -312,9 +312,9 @@ static void Cfg_AddObjects (ObjectStack *objects, const char **json)
 	} while (**json);
 }
 
-static void Cfg_OpenJSON (FILE **f)
+static void Cfg_OpenJSON (FILE ***f)
 {
-	*f = fopen("conf.json", "r");
+	*f = (FILE**) Util_OpenFile("conf.json", "r");
 	if (!*f) {
 		Util_Clear();
 		os::error("Config::load: %s\n", strerror(errno));
@@ -322,29 +322,29 @@ static void Cfg_OpenJSON (FILE **f)
 	}
 }
 
-static void Cfg_CloseJSON (FILE **f)
+static void Cfg_CloseJSON (FILE ***f)
 {
-	fclose(*f);
+	*f = (FILE**) Util_CloseFile(*f);
 }
 
-static size_t Cfg_SizeJSON (FILE **f)
+static size_t Cfg_SizeJSON (FILE ***f)
 {
-	fseek(*f, 0L, SEEK_SET);
-	size_t const beg = ftell(*f);
-	fseek(*f, 0L, SEEK_END);
-	size_t const end = ftell(*f);
+	fseek(**f, 0L, SEEK_SET);
+	size_t const beg = ftell(**f);
+	fseek(**f, 0L, SEEK_END);
+	size_t const end = ftell(**f);
 	size_t const size = (end - beg);
-	fseek(*f, 0L, SEEK_SET);
+	fseek(**f, 0L, SEEK_SET);
 	return size;
 }
 
-static void *Cfg_ReadJSON (FILE **f)
+static void *Cfg_ReadJSON (FILE ***f)
 {
 	size_t const bytes = Cfg_SizeJSON(f);
 	size_t const sz = (bytes + 1);
 	void *json = Util_Malloc(sz);
 	memset(json, 0, sz);
-	size_t const size = fread(json, 1, bytes, *f);
+	size_t const size = fread(json, 1, bytes, **f);
 	if (size != bytes) {
 		Cfg_CloseJSON(f);
 		Util_Clear();
@@ -357,7 +357,7 @@ static void *Cfg_ReadJSON (FILE **f)
 
 void Config::load ()
 {
-	FILE *f[] = {NULL};
+	FILE **f[] = {NULL};
 	Cfg_OpenJSON(f);
 	Cfg_SizeJSON(f);
 	void *json = Cfg_ReadJSON(f);

--- a/src/lmp/LMP.cpp
+++ b/src/lmp/LMP.cpp
@@ -20,26 +20,26 @@ static size_t lmp_SizeDataFile (FILE *f)
 
 void *lmp::load (void)
 {
-	FILE *lmp = fopen("data.lmp", "r");
+	FILE **lmp = (FILE**) Util_OpenFile("data.lmp", "r");
 	if (!lmp) {
 		os::error("lmp::load: IO ERROR\n");
 		return NULL;
 	}
 
-	size_t const len = lmp_SizeDataFile(lmp);
+	size_t const len = lmp_SizeDataFile(*lmp);
 	size_t const sz = (len + 1);
 	void *data = Util_Malloc(sz);
 	memset(data, 0, sz);
 
 	size_t const chunk = 1;
-	size_t const bytes = fread(data, chunk, len, lmp);
+	size_t const bytes = fread(data, chunk, len, *lmp);
 	if (len != bytes) {
 		os::error("lmp::load: IO READ ERROR\n");
-		fclose(lmp);
+		Util_CloseFile(lmp);
 		return NULL;
 	}
 
-	fclose(lmp);
+	Util_CloseFile(lmp);
 	return data;
 }
 

--- a/src/test/util/test.cpp
+++ b/src/test/util/test.cpp
@@ -54,6 +54,7 @@ void tutil16(void);
 void tutil17(void);
 void tutil18(void);
 void tutil19(void);
+void tutil20(void);
 
 #ifdef GXX
 Particle *_Particle(Vector *r,
@@ -103,6 +104,7 @@ int main ()
 	tutil17();
 	tutil18();
 	tutil19();
+	tutil20();
 	Util_Clear();
 	return 0;
 }
@@ -1394,20 +1396,20 @@ void tutil18 (void)
 	std /= (((double) numel) - 1.0);
 	std = sqrt(std);
 
-	FILE *f = fopen("hist.txt", "w");
+	FILE **f = (FILE**) Util_OpenFile("hist.txt", "w");
 	if (!f) {
 		Util_Clear();
 		return;
 	}
 
 	for (size_t bin = 0; bin != bins; ++bin) {
-		fprintf(f, "%zd\n", hist[bin]);
+		fprintf(*f, "%zd\n", hist[bin]);
 	}
 
 	printf("avg: %f\n", avg);
 	printf("std: %f\n", std);
 	printf("histogram of Gaussian random numbers has been exported to hist.txt\n");
-	fclose(f);
+	f = (FILE**) Util_CloseFile(f);
 	Util_Clear();
 }
 
@@ -1612,6 +1614,16 @@ void tutil19 (void)
 
 	App->_exec_ = true;
 	App->looper->loop();
+	Util_Clear();
+}
+
+void tutil20 (void)
+{
+	FILE **conf = (FILE**) Util_OpenFile("conf.json", "r");
+	FILE **lmp = (FILE**) Util_OpenFile("data.lmp", "r");
+	conf = (FILE**) Util_CloseFile(conf);
+	lmp = (FILE**) Util_CloseFile(lmp);
+	Util_CloseFiles();
 	Util_Clear();
 }
 


### PR DESCRIPTION
NOTE:
this is so that we can abort the program at any point without incurring on memory leaks ... though we still have some work to do to achieve that but this is good enough for committing

calls to `fopen()` and `fclose()` have been revised accordingly

valgrind reports no memory issues