### PR TITLE
adds unit spheres test run

### DIFF
--- a/include/BoundingBox.h
+++ b/include/BoundingBox.h
@@ -1,8 +1,9 @@
 #ifndef GUARD_BDX_BOUNDING_BOX_H
 #define GUARD_BDX_BOUNDING_BOX_H
 
+#include "BDXObject.h"
+
 struct Vector;
-struct BDXObject;
 
 struct BoundingBox : BDXObject
 {

--- a/include/Brownian.h
+++ b/include/Brownian.h
@@ -1,6 +1,7 @@
 #ifndef GUARD_BDX_BROWNIAN_H
 #define GUARD_BDX_BROWNIAN_H
 
+struct Vector;
 struct System;
 
 struct Brownian
@@ -10,6 +11,7 @@ struct Brownian
 	void bind(System *system);
 	void *operator new(size_t size);
 	void operator delete(void *p);
+	void generate();
 };
 
 #endif

--- a/include/Chiral.h
+++ b/include/Chiral.h
@@ -1,19 +1,16 @@
 #ifndef GUARD_BDX_CHIRAL_H
 #define GUARD_BDX_CHIRAL_H
 
+#include "Spheroid.h"
+
 struct ID;
 struct Kind;
 struct List;
 struct Vector;
-struct BDXObject;
-struct Particle;
-struct Spheroid;
 
 struct Chiral : Spheroid
 {
-	protected:
-	double c = 1.0;
-	public:
+	double _chiral_ = 1.0;
 	Chiral(Vector *r,
 	       Vector *u,
 	       Vector *E,

--- a/include/Driver.h
+++ b/include/Driver.h
@@ -10,6 +10,8 @@ struct Driver
 	void bind(BDX *app);
 	void *operator new(size_t size);
 	void operator delete(void *p);
+	void BrownianMotion();
+	void contain();
 };
 
 #endif

--- a/include/GFORTRAN.h
+++ b/include/GFORTRAN.h
@@ -5,7 +5,7 @@
 #define fanint(x) _gfortran_specific__anint_r8(x)
 
 extern "C" void _gfortran_random_r8(double*);
-extern "C" double _gfortran_specific__anint_r8(double*);
+extern "C" double _gfortran_specific__anint_r8(const double*);
 
 #endif
 

--- a/include/Janus.h
+++ b/include/Janus.h
@@ -1,18 +1,15 @@
 #ifndef GUARD_BDX_JANUS_H
 #define GUARD_BDX_JANUS_H
 
+#include "Sphere.h"
+
 struct ID;
 struct Kind;
 struct List;
 struct Vector;
-struct BDXObject;
-struct Particle;
-struct Sphere;
 
 struct Janus : Sphere
 {
-	public:
-	Vector *T = NULL;
 	Janus(Vector *r,
 	      Vector *u,
 	      Vector *E,

--- a/include/Particle.h
+++ b/include/Particle.h
@@ -1,30 +1,42 @@
 #ifndef GUARD_BDX_PARTICLE_H
 #define GUARD_BDX_PARTICLE_H
 
+#include "BDXObject.h"
+
 struct ID;
 struct Kind;
 struct List;
 struct Vector;
-struct BDXObject;
 
 struct Particle : BDXObject
 {
 	Vector *u = NULL;
 	Vector *E = NULL;
 	Vector *d = NULL;
+	Vector *F = NULL;
+	Vector *T = NULL;
 	List *list = NULL;
 	ID *id = NULL;
 	Kind *kind = NULL;
+	double _radius_ = 1.0;
 	Particle(Vector *r,
 		 Vector *u,
 		 Vector *E,
 		 Vector *d,
+		 Vector *F,
+		 Vector *T,
 		 List *list,
 		 ID *id,
-		 Kind *kind);
+		 Kind *kind,
+		 double const a);
 	virtual void ia(const Particle *particle) = 0;
 	void *operator new(size_t size);
 	void operator delete(void *p);
+	void _updatePositionVectorComponent_(double *x,
+					     double const F_x,
+					     double const mobility);
+	void _translate_(double const mobility);
+	void BrownianMotion();
 };
 
 #endif

--- a/include/Sphere.h
+++ b/include/Sphere.h
@@ -1,24 +1,21 @@
 #ifndef GUARD_BDX_SPHERE_H
 #define GUARD_BDX_SPHERE_H
 
+#include "Particle.h"
+
 struct ID;
 struct Kind;
 struct Vector;
-struct BDXObject;
-struct Particle;
 struct List;
 
 struct Sphere : Particle
 {
-	protected:
-	double a = 1.0;
-	public:
-	Vector *F = NULL;
 	Sphere(Vector *r,
 	       Vector *u,
 	       Vector *E,
 	       Vector *d,
 	       Vector *F,
+	       Vector *T,
 	       List *list,
 	       ID *id,
 	       Kind *kind,

--- a/include/Spheroid.h
+++ b/include/Spheroid.h
@@ -1,21 +1,17 @@
 #ifndef GUARD_BDX_SPHEROID_H
 #define GUARD_BDX_SPHEROID_H
 
+#include "Particle.h"
+
 struct ID;
 struct Kind;
 struct List;
 struct Vector;
-struct BDXObject;
-struct Particle;
 
 struct Spheroid : Particle
 {
-	protected:
-	double a = 1.0;
-	double b = 3.0;
-	public:
-	Vector *F = NULL;
-	Vector *T = NULL;
+	double _radius_minor_ = 1.0;
+	double _radius_major_ = 3.0;
 	Spheroid(Vector *r,
 	         Vector *u,
 	         Vector *E,

--- a/include/System.h
+++ b/include/System.h
@@ -16,6 +16,7 @@ struct System
 	void bind(BDX *app);
 	void *operator new(size_t size);
 	void operator delete(void *p);
+	void contain();
 };
 
 #endif

--- a/include/Timer.h
+++ b/include/Timer.h
@@ -1,16 +1,25 @@
 #ifndef GUARD_BDX_TIMER_H
 #define GUARD_BDX_TIMER_H
 
+#include <ctime>
+#include <cstdlib>
+
 struct BDX;
 
 struct Timer
 {
 	BDX *app = NULL;
+	ssize_t _begin_ = 0;
+	ssize_t _end_ = 0;
+	ssize_t _walltime_ = 0;
 	Timer();
+	Timer(ssize_t const walltime);
 	void bind(BDX *app);
-	void time();
 	void *operator new(size_t size);
 	void operator delete(void *p);
+	void etime();
+	void begin();
+	void end();
 };
 
 #endif

--- a/make-inc
+++ b/make-inc
@@ -14,5 +14,5 @@
 #
 
 CXX = g++-10
-CXXOPT = -DGXX=1 -DDEBUG=1 -std=gnu++11 -g -Wall -Wextra -Wformat -O0
+CXXOPT = -DGXX=1 -DDEBUG=1 -DGLOBAL_TIME_STEP=1.52587890625e-05 -std=gnu++11 -g -Wall -Wextra -Wformat -O0
 LIBS = -lgfortran

--- a/src/Brownian/Brownian.cpp
+++ b/src/Brownian/Brownian.cpp
@@ -1,4 +1,10 @@
 #include "util.h"
+#include "BDX.h"
+#include "Handler.h"
+#include "System.h"
+#include "Vector.h"
+#include "Random.h"
+#include "Particle.h"
 #include "Brownian.h"
 
 Brownian::Brownian ()
@@ -20,6 +26,27 @@ void Brownian::operator delete (void *p)
 {
 	p = util::free(p);
 }
+
+static void BrownianForce (double *x, const double *r)
+{
+	*x = *r;
+}
+
+void Brownian::generate ()
+{
+	Random *rand = this->system->app->random;
+	Handler *h = this->system->handler;
+	for (Particle **particles = h->begin(); particles != h->end(); ++particles) {
+		Particle *particle = *particles;
+		double const x = rand->fetch();
+		double const y = rand->fetch();
+		double const z = rand->fetch();
+		BrownianForce(&particle->F->x, &x);
+		BrownianForce(&particle->F->y, &y);
+		BrownianForce(&particle->F->z, &z);
+	}
+}
+
 
 /*
 

--- a/src/chiral/Chiral.cpp
+++ b/src/chiral/Chiral.cpp
@@ -3,10 +3,7 @@
 #include "ID.h"
 #include "Kind.h"
 #include "Vector.h"
-#include "BDXObject.h"
-#include "Particle.h"
 #include "List.h"
-#include "Spheroid.h"
 #include "Chiral.h"
 
 Chiral::Chiral (Vector *r,
@@ -22,14 +19,14 @@ Chiral::Chiral (Vector *r,
 		double const b,
 		double const c):
 		Spheroid(r, u, E, d, F, T, list, id, kind, a, b),
-		c(c)
+		_chiral_(c)
 {
 	return;
 }
 
 double Chiral::chiral () const
 {
-	return this->c;
+	return this->_chiral_;
 }
 
 void Chiral::ia (const Particle *particle)

--- a/src/driver/Driver.cpp
+++ b/src/driver/Driver.cpp
@@ -1,5 +1,10 @@
 #include "util.h"
 #include "Driver.h"
+#include "Brownian.h"
+#include "Handler.h"
+#include "Particle.h"
+#include "System.h"
+#include "BDX.h"
 
 Driver::Driver ()
 {
@@ -19,6 +24,23 @@ void *Driver::operator new (size_t size)
 void Driver::operator delete (void *p)
 {
 	p = util::free(p);
+}
+
+void Driver::BrownianMotion ()
+{
+	struct Brownian *Brownian = this->app->system->Brownian;
+	Brownian->generate();
+	Handler *h = this->app->system->handler;
+	for (Particle **particles = h->begin(); particles != h->end(); ++particles) {
+		Particle *p = *particles;
+		p->BrownianMotion();
+	}
+}
+
+void Driver::contain ()
+{
+	System *system = this->app->system;
+	system->contain();
 }
 
 /*

--- a/src/janus/Janus.cpp
+++ b/src/janus/Janus.cpp
@@ -3,10 +3,7 @@
 #include "ID.h"
 #include "Kind.h"
 #include "Vector.h"
-#include "BDXObject.h"
-#include "Particle.h"
 #include "List.h"
-#include "Sphere.h"
 #include "Janus.h"
 
 Janus::Janus (Vector *r,
@@ -19,9 +16,9 @@ Janus::Janus (Vector *r,
 	      ID *id,
 	      Kind *kind,
 	      double const a):
-	      Sphere(r, u, E, d, F, list, id, kind, a)
+	      Sphere(r, u, E, d, F, T, list, id, kind, a)
 {
-	this->T = T;
+	return;
 }
 
 void Janus::ia (const Particle *particle)

--- a/src/looper/Looper.cpp
+++ b/src/looper/Looper.cpp
@@ -1,6 +1,7 @@
 #include "util.h"
-#include "Timer.h"
+#include "Driver.h"
 #include "Looper.h"
+#include "Timer.h"
 #include "BDX.h"
 
 Looper::Looper ()
@@ -25,8 +26,13 @@ void Looper::operator delete (void *p)
 
 void Looper::loop ()
 {
+	Driver *driver = this->app->driver;
+	this->app->timer->begin();
 	while (this->app->exec()) {
-		this->app->timer->time();
+		driver->BrownianMotion();
+		driver->contain();
+		this->app->timer->end();
+		this->app->timer->etime();
 	}
 }
 

--- a/src/particle/Particle.cpp
+++ b/src/particle/Particle.cpp
@@ -1,26 +1,32 @@
+#include <cmath>
 #include "util.h"
 #include "ID.h"
 #include "Kind.h"
 #include "Vector.h"
-#include "BDXObject.h"
-#include "Particle.h"
 #include "List.h"
+#include "Particle.h"
 
 Particle::Particle (Vector *r,
 		    Vector *u,
 		    Vector *E,
 		    Vector *d,
+		    Vector *F,
+		    Vector *T,
 		    List *list,
 		    ID *id,
-		    Kind *kind):
+		    Kind *kind,
+		    double const a):
 		    BDXObject(r)
 {
 	this->u = u;
 	this->E = E;
 	this->d = d;
+	this->F = F;
+	this->T = T;
 	this->list = list;
 	this->id = id;
 	this->kind = kind;
+	this->_radius_ = a;
 }
 
 void *Particle::operator new (size_t size)
@@ -32,6 +38,33 @@ void Particle::operator delete (void *p)
 {
 	p = util::free(p);
 }
+
+void Particle::_updatePositionVectorComponent_ (double *x,
+					        double const F_x,
+					        double const mobility)
+{
+	double const mob = mobility;
+	*x += (mob * F_x);
+}
+
+void Particle::_translate_ (double const mobility)
+{
+	double const mob = mobility;
+	this->_updatePositionVectorComponent_(&this->r->x, this->F->x, mob);
+	this->_updatePositionVectorComponent_(&this->r->y, this->F->y, mob);
+	this->_updatePositionVectorComponent_(&this->r->z, this->F->z, mob);
+	this->_updatePositionVectorComponent_(&this->u->x, this->F->x, mob);
+	this->_updatePositionVectorComponent_(&this->u->y, this->F->y, mob);
+	this->_updatePositionVectorComponent_(&this->u->z, this->F->z, mob);
+}
+
+void Particle::BrownianMotion ()
+{
+	constexpr double dt = GLOBAL_TIME_STEP;
+	constexpr double mobility = sqrt(2.0 * dt);
+	this->_translate_(mobility);
+}
+
 
 /*
 

--- a/src/sphere/Sphere.cpp
+++ b/src/sphere/Sphere.cpp
@@ -3,8 +3,6 @@
 #include "ID.h"
 #include "Kind.h"
 #include "Vector.h"
-#include "BDXObject.h"
-#include "Particle.h"
 #include "List.h"
 #include "Sphere.h"
 
@@ -13,19 +11,19 @@ Sphere::Sphere (Vector *r,
 		Vector *E,
 		Vector *d,
 		Vector *F,
+		Vector *T,
 		List *list,
 		ID *id,
 		Kind *kind,
 		double const a):
-		Particle(r, u, E, d, list, id, kind),
-		a(a)
+		Particle(r, u, E, d, F, T, list, id, kind, a)
 {
-	this->F = F;
+	return;
 }
 
 double Sphere::radius () const
 {
-	return this->a;
+	return this->_radius_;
 }
 
 void Sphere::ia (const Particle *particle)

--- a/src/spheroid/Spheroid.cpp
+++ b/src/spheroid/Spheroid.cpp
@@ -3,8 +3,6 @@
 #include "ID.h"
 #include "Kind.h"
 #include "Vector.h"
-#include "BDXObject.h"
-#include "Particle.h"
 #include "List.h"
 #include "Spheroid.h"
 
@@ -19,22 +17,21 @@ Spheroid::Spheroid (Vector *r,
 		    Kind *kind,
 		    double const a,
 		    double const b):
-		    Particle(r, u, E, d, list, id, kind),
-		    a(a),
-		    b(b)
+		    Particle(r, u, E, d, F, T, list, id, kind, a),
+		    _radius_minor_(a),
+		    _radius_major_(b)
 {
-	this->F = F;
-	this->T = T;
+	return;
 }
 
 double Spheroid::radius_minor () const
 {
-	return this->a;
+	return this->_radius_minor_;
 }
 
 double Spheroid::radius_major () const
 {
-	return this->b;
+	return this->_radius_major_;
 }
 
 void Spheroid::ia (const Particle *particle)

--- a/src/system/System.cpp
+++ b/src/system/System.cpp
@@ -1,5 +1,11 @@
+#include "os.h"
 #include "util.h"
 #include "Brownian.h"
+#include "BoundingBox.h"
+#include "Handler.h"
+#include "Vector.h"
+#include "Particle.h"
+#include "GFORTRAN.h"
 #include "System.h"
 
 System::System (BoundingBox *bb, struct Brownian *Brownian, Handler *handler)
@@ -23,6 +29,26 @@ void *System::operator new (size_t size)
 void System::operator delete (void *p)
 {
 	p = util::free(p);
+}
+
+void container (double *x, double const *len)
+{
+	const double t = (*x / *len);
+	*x -= *len * fanint(&t);
+}
+
+void System::contain ()
+{
+	Handler *h = this->handler;
+	for (Particle **particles = h->begin(); particles != h->end(); ++particles) {
+		double const l = this->bb->length();
+		double const w = this->bb->width();
+		double const h = this->bb->height();
+		Particle *particle = *particles;
+		container(&particle->r->x, &l);
+		container(&particle->r->y, &w);
+		container(&particle->r->z, &h);
+	}
 }
 
 /*

--- a/src/test/util/test.cpp
+++ b/src/test/util/test.cpp
@@ -55,6 +55,7 @@ void tutil17(void);
 void tutil18(void);
 void tutil19(void);
 void tutil20(void);
+void tutil21(void);
 
 #ifdef GXX
 Particle *_Particle(Vector *r,
@@ -62,19 +63,21 @@ Particle *_Particle(Vector *r,
 		    Vector *E,
 		    Vector *d,
 		    Vector *F,
+		    Vector *T,
 		    List *list,
 		    ID *id,
 		    Kind *kind,
 		    double const a,
 		    double const b,
 		    double const c)
-__attribute__ ((nonnull (1, 2, 3, 4, 5, 6, 7, 8)));
+__attribute__ ((nonnull (1, 2, 3, 4, 5, 6, 7, 8, 9)));
 #else
 Particle *_Particle(Vector *r,
 		    Vector *u,
 		    Vector *E,
 		    Vector *d,
 		    Vector *F,
+		    Vector *T,
 		    List *list,
 		    ID *id,
 		    Kind *kind,
@@ -105,6 +108,7 @@ int main ()
 	tutil18();
 	tutil19();
 	tutil20();
+	tutil21();
 	util::clearall();
 	return 0;
 }
@@ -114,6 +118,7 @@ Particle *_Particle (Vector *r,
 		     Vector *E,
 		     Vector *d,
 		     Vector *F,
+		     Vector *T,
 		     List *list,
 		     ID *id,
 		     Kind *kind,
@@ -121,32 +126,28 @@ Particle *_Particle (Vector *r,
 		     double const b,
 		     double const c)
 {
-	Vector *T = NULL;
 	Particle *particle = NULL;
 	kind_t const k = kind->k();
 	switch(k)
 	{
 		case SPHERE:
-		particle = new Sphere(r, u, E, d, F, list, id, kind, a);
+		particle = new Sphere(r, u, E, d, F, T, list, id, kind, a);
 		break;
 
 		case JANUS:
-		T = new Vector();
 		particle = new Janus(r, u, E, d, F, T, list, id, kind, a);
 		break;
 
 		case SPHEROID:
-		T = new Vector();
 		particle = new Spheroid(r, u, E, d, F, T, list, id, kind, a, b);
 		break;
 
 		case CHIRAL:
-		T = new Vector();
 		particle = new Chiral(r, u, E, d, F, T, list, id, kind, a, b, c);
 		break;
 
 		default:
-		particle = new Sphere(r, u, E, d, F, list, id, kind, a);
+		particle = new Sphere(r, u, E, d, F, T, list, id, kind, a);
 	}
 
 	return particle;
@@ -301,11 +302,12 @@ void tutil10 (void)
 		Vector *E = new Vector();
 		Vector *d = new Vector(0, 0, 1);
 		Vector *F = new Vector();
+		Vector *T = new Vector();
 		Stack *stack = new Stack();
 		List *list = new List(stack);
 		double const frand_max = RAND_MAX;
 		double const a = rand() / frand_max;
-		Sphere *sphere = new Sphere(r, u, E, d, F, list, id, kind, a);
+		Sphere *sphere = new Sphere(r, u, E, d, F, T, list, id, kind, a);
 		printf("radius: %f\n", sphere->radius());
 		spheres[i] = sphere;
 	}
@@ -329,11 +331,12 @@ void tutil10 (void)
 		Vector *E = new Vector();
 		Vector *d = new Vector(0, 0, 1);
 		Vector *F = new Vector();
+		Vector *T = new Vector();
 		Stack *stack = new Stack();
 		List *list = new List(stack);
 		double const frand_max = RAND_MAX;
 		double const a = rand() / frand_max;
-		Sphere *sphere = new Sphere(r, u, E, d, F, list, id, kind, a);
+		Sphere *sphere = new Sphere(r, u, E, d, F, T, list, id, kind, a);
 		spheres[i] = sphere;
 	}
 
@@ -361,13 +364,14 @@ void tutil11 (void)
 		Vector *E = new Vector();
 		Vector *d = new Vector(0, 0, 1);
 		Vector *F = new Vector();
+		Vector *T = new Vector();
 		Stack *stack = new Stack();
 		List *list = new List(stack);
 		double const frand_max = RAND_MAX;
 		double const a = rand() / frand_max;
 		double const b = ASPECT_RATIO * a;
 		double const c = rand() / frand_max;
-		Particle *particle = _Particle(r, u, E, d, F, list, id, kind, a, b, c);
+		Particle *particle = _Particle(r, u, E, d, F, T, list, id, kind, a, b, c);
 		particles[i] = particle;
 	}
 
@@ -408,13 +412,14 @@ void tutil11 (void)
 		Vector *E = new Vector();
 		Vector *d = new Vector(0, 0, 1);
 		Vector *F = new Vector();
+		Vector *T = new Vector();
 		Stack *stack = new Stack();
 		List *list = new List(stack);
 		double const frand_max = RAND_MAX;
 		double const a = rand() / frand_max;
 		double const b = ASPECT_RATIO * a;
 		double const c = rand() / frand_max;
-		Particle *particle = _Particle(r, u, E, d, F, list, id, kind, a, b, c);
+		Particle *particle = _Particle(r, u, E, d, F, T, list, id, kind, a, b, c);
 		particles[i] = particle;
 	}
 
@@ -442,13 +447,14 @@ void tutil12 (void)
 		Vector *E = new Vector();
 		Vector *d = new Vector(0, 0, 1);
 		Vector *F = new Vector();
+		Vector *T = new Vector();
 		Stack *stack = new Stack();
 		List *list = new List(stack);
 		double const frand_max = RAND_MAX;
 		double const a = rand() / frand_max;
 		double const b = ASPECT_RATIO * a;
 		double const c = rand() / frand_max;
-		Particle *particle = _Particle(r, u, E, d, F, list, id, kind, a, b, c);
+		Particle *particle = _Particle(r, u, E, d, F, T, list, id, kind, a, b, c);
 		stack->add((void*) particle);
 	}
 
@@ -492,13 +498,14 @@ void tutil12 (void)
 		Vector *E = new Vector();
 		Vector *d = new Vector(0, 0, 1);
 		Vector *F = new Vector();
+		Vector *T = new Vector();
 		Stack *stack = new Stack();
 		List *list = new List(stack);
 		double const frand_max = RAND_MAX;
 		double const a = rand() / frand_max;
 		double const b = ASPECT_RATIO * a;
 		double const c = rand() / frand_max;
-		Particle *particle = _Particle(r, u, E, d, F, list, id, kind, a, b, c);
+		Particle *particle = _Particle(r, u, E, d, F, T, list, id, kind, a, b, c);
 		stack->add((void*) particle);
 	}
 
@@ -527,13 +534,14 @@ void tutil13 (void)
 		Vector *E = new Vector();
 		Vector *d = new Vector(0, 0, 1);
 		Vector *F = new Vector();
+		Vector *T = new Vector();
 		Stack *stack = new Stack();
 		List *list = new List(stack);
 		double const frand_max = RAND_MAX;
 		double const a = rand() / frand_max;
 		double const b = ASPECT_RATIO * a;
 		double const c = rand() / frand_max;
-		Particle *particle = _Particle(r, u, E, d, F, list, id, kind, a, b, c);
+		Particle *particle = _Particle(r, u, E, d, F, T, list, id, kind, a, b, c);
 		handler->add(particle);
 	}
 
@@ -566,13 +574,14 @@ void tutil13 (void)
 		Vector *E = new Vector();
 		Vector *d = new Vector(0, 0, 1);
 		Vector *F = new Vector();
+		Vector *T = new Vector();
 		Stack *stack = new Stack();
 		List *list = new List(stack);
 		double const frand_max = RAND_MAX;
 		double const a = rand() / frand_max;
 		double const b = ASPECT_RATIO * a;
 		double const c = rand() / frand_max;
-		Particle *particle = _Particle(r, u, E, d, F, list, id, kind, a, b, c);
+		Particle *particle = _Particle(r, u, E, d, F, T, list, id, kind, a, b, c);
 		handler->add(particle);
 	}
 
@@ -793,9 +802,10 @@ void tutil19 (void)
 		Vector *E = new Vector();
 		Vector *d = new Vector(0, 0, 1);
 		Vector *F = new Vector();
+		Vector *T = new Vector();
 		Stack *stack = new Stack();
 		List *list = new List(stack);
-		Particle *particle = _Particle(r, u, E, d, F, list, id, kind, a, 0, 0);
+		Particle *particle = _Particle(r, u, E, d, F, T, list, id, kind, a, 0, 0);
 		handler->add(particle);
 
 		it += 3; // skips optional director (of zeros)
@@ -813,6 +823,116 @@ void tutil20 (void)
 	conf = (FILE**) util::fclose(conf);
 	lmp = (FILE**) util::fclose(lmp);
 	util::fcloseall();
+	util::clearall();
+}
+
+/*
+
+void tutil21(void)
+- imports LAMMPS (unit) spheres data
+- performs a 15 minute simulation test run
+- checks that no particle is outside the system boundaries when the BDX simulation ends
+- displays the outcome of the test on the console
+
+*/
+
+void tutil21 (void)
+{
+	double const length = 0;
+	double const width = 0;
+	double const height = 0;
+	BoundingBox *bb = new BoundingBox(new Vector(), length, width, height);
+	struct Brownian *Brownian = new struct Brownian();
+	Handler *handler = new Handler(new Stack());
+	System *system = new System(bb, Brownian, handler);
+	Prompt *prompt = new Prompt();
+	Config *config = new Config();
+	ssize_t const walltime = 15 * 60;
+	Timer *timer = new Timer(walltime);
+	Random *random = new Random(random::NORMAL);
+	Looper *looper = new Looper();
+	Driver *driver = new Driver();
+	Integrator *integrator = new Integrator();
+	Logger *logger = new Logger();
+	BDX *App = new BDX(prompt,
+			   config,
+			   timer,
+			   random,
+			   looper,
+			   driver,
+			   integrator,
+			   logger,
+			   system);
+
+	os::print("configuring BDX App\n");
+	config->load();
+	config->parse();
+	config->config();
+
+	Stack *stack = new Stack();
+	void *data = lmp::load();
+	size_t const num_particles = lmp::parse(data, stack);
+	const double **it = (const double**) stack->begin();
+	for (size_t i = 0; i != num_particles; ++i) {
+		double const a = 1.0;
+		ID *id = new ID(i);
+		Kind *kind = new Kind(SPHERE);
+
+		it += 2; // skips LAMMPS ID and Group
+
+		const double **coords = it;
+		double const x = *coords[0];
+		double const y = *coords[1];
+		double const z = *coords[2];
+
+		it += 3;
+
+		Vector *r = new Vector(x, y, z);
+		Vector *u = new Vector();
+		Vector *E = new Vector();
+		Vector *d = new Vector(0, 0, 1);
+		Vector *F = new Vector();
+		Vector *T = new Vector();
+		List *list = new List(new Stack());
+		Particle *particle = _Particle(r, u, E, d, F, T, list, id, kind, a, 0, 0);
+		handler->add(particle);
+
+		it += 3; // skips optional director (of zeros)
+	}
+
+	os::print("executing BDX test-run\n");
+	App->_exec_ = true;
+	App->looper->loop();
+
+	ssize_t fails = 0;
+	Handler *h = handler;
+	for (Particle **particles = h->begin(); particles != h->end(); ++particles) {
+
+		Particle *p = *particles;
+
+		if (p->r->x < -0.5 * bb->length() || p->r->x > 0.5 * bb->length()) {
+			++fails;
+			break;
+		}
+
+		if (p->r->y < -0.5 * bb->width() || p->r->y > 0.5 * bb->width()) {
+			++fails;
+			break;
+		}
+
+		if (p->r->z < -0.5 * bb->height() || p->r->z > 0.5 * bb->height()) {
+			++fails;
+			break;
+		}
+	}
+
+	os::print("particle-container-test: ");
+	if (fails != 0) {
+		os::print("FAIL\n");
+	} else {
+		os::print("PASS\n");
+	}
+
 	util::clearall();
 }
 

--- a/src/timer/Timer.cpp
+++ b/src/timer/Timer.cpp
@@ -7,6 +7,11 @@ Timer::Timer ()
 	return;
 }
 
+Timer::Timer (ssize_t const walltime) : _walltime_(walltime)
+{
+	return;
+}
+
 void Timer::bind (BDX *app)
 {
 	this->app = app;
@@ -22,9 +27,24 @@ void Timer::operator delete (void *p)
 	p = util::free(p);
 }
 
-void Timer::time ()
+void Timer::begin ()
 {
-	this->app->_exec_ = false;
+	this->_begin_ = ((ssize_t) time(NULL));
+}
+
+void Timer::end ()
+{
+	this->_end_ = ((ssize_t) time(NULL));
+}
+
+void Timer::etime ()
+{
+	ssize_t const walltime = this->_walltime_;
+	ssize_t const elapsedTime = (this->_end_ - this->_begin_);
+	ssize_t const etime = elapsedTime;
+	if (etime >= walltime) {
+		this->app->_exec_ = false;
+	}
 }
 
 /*


### PR DESCRIPTION
NOTES:
not my favorite thing to commit many changes at once but it is with good reason

- BDX passes unit sphere test run
- includes header of base classes in the the derived class headers; this is what you want to do since forward declaration of the base class does not have the necessary info
- uses _name_ instead of private and protected data and function members so these have been removed to make development easier
- the base particle class is essentially a sphere so added force, torque, and radius properties
- renames some variables to make the code easier to understand
- adds walltime to timer
- adds global time-step MACRO so that we can compute the costly Brownian "mobility" during compilation
- adds code to simulate Brownian motion
- adds code to contain particles within the system limits
- revises _Particle() util in `src/test/util/test.cpp` accordingly

Note that we have yet to account for different particle sizes for simulating Brownian motion, this shall be added later

valgrind reports no memory issues