### PR TITLE
removes `<cstdlib>` from timer

### DIFF
--- a/include/Timer.h
+++ b/include/Timer.h
@@ -2,18 +2,17 @@
 #define GUARD_BDX_TIMER_H
 
 #include <ctime>
-#include <cstdlib>
 
 struct BDX;
 
 struct Timer
 {
 	BDX *app = NULL;
-	ssize_t _begin_ = 0;
-	ssize_t _end_ = 0;
-	ssize_t _walltime_ = 0;
+	time_t _begin_ = 0;
+	time_t _end_ = 0;
+	time_t _walltime_ = 0;
 	Timer();
-	Timer(ssize_t const walltime);
+	Timer(time_t const walltime);
 	void bind(BDX *app);
 	void *operator new(size_t size);
 	void operator delete(void *p);

--- a/src/test/util/test.cpp
+++ b/src/test/util/test.cpp
@@ -847,7 +847,7 @@ void tutil21 (void)
 	System *system = new System(bb, Brownian, handler);
 	Prompt *prompt = new Prompt();
 	Config *config = new Config();
-	ssize_t const walltime = 15 * 60;
+	time_t const walltime = 15 * 60;
 	Timer *timer = new Timer(walltime);
 	Random *random = new Random(random::NORMAL);
 	Looper *looper = new Looper();

--- a/src/timer/Timer.cpp
+++ b/src/timer/Timer.cpp
@@ -1,3 +1,4 @@
+#include <cstdlib>
 #include "util.h"
 #include "Timer.h"
 #include "BDX.h"
@@ -29,12 +30,12 @@ void Timer::operator delete (void *p)
 
 void Timer::begin ()
 {
-	this->_begin_ = ((ssize_t) time(NULL));
+	this->_begin_ = time(NULL);
 }
 
 void Timer::end ()
 {
-	this->_end_ = ((ssize_t) time(NULL));
+	this->_end_ = time(NULL);
 }
 
 void Timer::etime ()


### PR DESCRIPTION
NOTE:
we can use `time_t` to store the properties of timer, besides that's the type of the object returned by `time()`

we needed `<cstdlib>` for `ssize_t`