### PR TITLE
dumps particle data in plain text

### DIFF
--- a/include/ID.h
+++ b/include/ID.h
@@ -3,11 +3,12 @@
 
 struct ID
 {
-	long i;
+	long i = 0L;
 	ID();
 	ID(long const i);
 	void *operator new(size_t size);
 	void operator delete(void *p);
+	void txt(void *stream) const;
 };
 
 #endif

--- a/include/Kind.h
+++ b/include/Kind.h
@@ -18,6 +18,7 @@ struct Kind
 	static kind_t enumerator(const char *kind);
 	void *operator new(size_t size);
 	void operator delete(void *p);
+	void txt(void *stream) const;
 };
 
 #endif

--- a/include/Logger.h
+++ b/include/Logger.h
@@ -10,6 +10,7 @@ struct Logger
 	void bind(BDX *app);
 	void *operator new(size_t size);
 	void operator delete(void *p);
+	void txt() const;
 };
 
 #endif

--- a/include/Looper.h
+++ b/include/Looper.h
@@ -1,16 +1,20 @@
 #ifndef GUARD_BDX_LOOPER_H
 #define GUARD_BDX_LOOPER_H
 
+#include <cstddef>
+
 struct BDX;
 
 struct Looper
 {
 	BDX *app = NULL;
+	size_t _step_ = 0;
 	Looper();
 	void bind(BDX *app);
-	void loop();
 	void *operator new(size_t size);
 	void operator delete(void *p);
+	size_t step() const;
+	void loop();
 };
 
 #endif

--- a/include/Particle.h
+++ b/include/Particle.h
@@ -37,6 +37,8 @@ struct Particle : BDXObject
 					     double const mobility);
 	void _translate_(double const mobility);
 	void BrownianMotion();
+	void txt(void *stream) const;
+	double radius() const;
 };
 
 #endif

--- a/include/Sphere.h
+++ b/include/Sphere.h
@@ -20,7 +20,6 @@ struct Sphere : Particle
 	       ID *id,
 	       Kind *kind,
 	       double const a);
-	double radius() const;
 	void ia(const Particle *particle);
 	void *operator new(size_t size);
 	void operator delete(void *p);

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -10,6 +10,7 @@ struct Vector {
 	void copy(const Vector *vector);
 	void *operator new(size_t size);
 	void operator delete(void *p);
+	void txt(void *stream) const;
 };
 
 #endif

--- a/make-inc
+++ b/make-inc
@@ -13,6 +13,8 @@
 # (at your option) any later version.
 #
 
+GLOBALS = -DGLOBAL_TIME_STEP=1.52587890625e-05\
+	  -DGLOBAL_TIME_STEP_LOGGER=0.015625
 CXX = g++-10
-CXXOPT = -DGXX=1 -DDEBUG=1 -DGLOBAL_TIME_STEP=1.52587890625e-05 -std=gnu++11 -g -Wall -Wextra -Wformat -O0
+CXXOPT = -DGXX=1 -DDEBUG=1 $(GLOBALS) -std=gnu++11 -g -Wall -Wextra -Wformat -O0
 LIBS = -lgfortran

--- a/src/id/ID.cpp
+++ b/src/id/ID.cpp
@@ -1,3 +1,5 @@
+#include <cstdio>
+#include <cstdlib>
 #include "util.h"
 #include "ID.h"
 
@@ -19,6 +21,13 @@ void *ID::operator new (size_t size)
 void ID::operator delete (void *p)
 {
 	p = util::free(p);
+}
+
+void ID::txt (void *stream) const
+{
+	FILE *f = (FILE*) stream;
+	ssize_t id = ((ssize_t) this->i);
+	fprintf(f, "%zd ", id);
 }
 
 /*

--- a/src/kind/Kind.cpp
+++ b/src/kind/Kind.cpp
@@ -1,3 +1,4 @@
+#include <cstdio>
 #include <cstring>
 
 #include "util.h"
@@ -65,6 +66,13 @@ void *Kind::operator new (size_t size)
 void Kind::operator delete (void *p)
 {
 	p = util::free(p);
+}
+
+void Kind::txt (void *stream) const
+{
+	FILE *f = (FILE*) stream;
+	ssize_t const k = ((ssize_t) this->k());
+	fprintf(f, "%zd ", k);
 }
 
 /*

--- a/src/logger/Logger.cpp
+++ b/src/logger/Logger.cpp
@@ -1,5 +1,13 @@
+#include <cstdio>
+#include <cstring>
+#include "os.h"
 #include "util.h"
+#include "Looper.h"
 #include "Logger.h"
+#include "System.h"
+#include "Particle.h"
+#include "Handler.h"
+#include "BDX.h"
 
 Logger::Logger ()
 {
@@ -19,6 +27,32 @@ void *Logger::operator new (size_t size)
 void Logger::operator delete (void *p)
 {
 	p = util::free(p);
+}
+
+void Logger::txt () const
+{
+	constexpr char name[] = "particles-";
+	constexpr char ext[] = ".txt";
+	char anum[16];
+	memset(anum, 0, 16);
+	Looper *looper = this->app->looper;
+	size_t const step = looper->step();
+	sprintf(anum, "%015zu", step);
+	constexpr size_t len = 1 + (strlen(name) + strlen(ext) + 16);
+	char filename[len];
+	filename[0] = 0;
+	strcat(filename, name);
+	strcat(filename, anum);
+	strcat(filename, ext);
+
+	FILE **stream = (FILE**) util::fopen(filename, "w");
+	Handler *h = this->app->system->handler;
+	for (Particle **particles = h->begin(); particles != h->end(); ++particles) {
+		Particle *particle = *particles;
+		particle->txt(*stream);
+	}
+
+	util::fclose(stream);
 }
 
 /*

--- a/src/looper/Looper.cpp
+++ b/src/looper/Looper.cpp
@@ -1,6 +1,7 @@
 #include "util.h"
 #include "Driver.h"
 #include "Looper.h"
+#include "Logger.h"
 #include "Timer.h"
 #include "BDX.h"
 
@@ -24,15 +25,29 @@ void Looper::operator delete (void *p)
 	p = util::free(p);
 }
 
+size_t Looper::step () const
+{
+	return this->_step_;
+}
+
 void Looper::loop ()
 {
+	Logger *logger = this->app->logger;
 	Driver *driver = this->app->driver;
 	this->app->timer->begin();
+	this->_step_ = 0;
 	while (this->app->exec()) {
-		driver->BrownianMotion();
-		driver->contain();
+		size_t istep = 0;
+		constexpr size_t isteps = (GLOBAL_TIME_STEP_LOGGER / GLOBAL_TIME_STEP);
+		while (istep != isteps) {
+			driver->BrownianMotion();
+			driver->contain();
+			++istep;
+		}
+		logger->txt();
 		this->app->timer->end();
 		this->app->timer->etime();
+		this->_step_ += isteps;
 	}
 }
 

--- a/src/particle/Particle.cpp
+++ b/src/particle/Particle.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <cstdio>
 #include "util.h"
 #include "ID.h"
 #include "Kind.h"
@@ -39,6 +40,11 @@ void Particle::operator delete (void *p)
 	p = util::free(p);
 }
 
+double Particle::radius () const
+{
+	return this->_radius_;
+}
+
 void Particle::_updatePositionVectorComponent_ (double *x,
 					        double const F_x,
 					        double const mobility)
@@ -65,6 +71,19 @@ void Particle::BrownianMotion ()
 	this->_translate_(mobility);
 }
 
+void Particle::txt (void *stream) const
+{
+	FILE *f = (FILE*) stream;
+	this->id->txt(stream);
+	this->kind->txt(stream);
+	this->r->txt(stream);
+	this->u->txt(stream);
+	this->E->txt(stream);
+	this->d->txt(stream);
+	this->F->txt(stream);
+	this->T->txt(stream);
+	fprintf(f, "%.15e \n", this->radius());
+}
 
 /*
 

--- a/src/sphere/Sphere.cpp
+++ b/src/sphere/Sphere.cpp
@@ -21,11 +21,6 @@ Sphere::Sphere (Vector *r,
 	return;
 }
 
-double Sphere::radius () const
-{
-	return this->_radius_;
-}
-
 void Sphere::ia (const Particle *particle)
 {
 	const Particle *that = particle;

--- a/src/vector/Vector.cpp
+++ b/src/vector/Vector.cpp
@@ -1,3 +1,4 @@
+#include <cstdio>
 #include "util.h"
 #include "Vector.h"
 
@@ -26,6 +27,12 @@ void *Vector::operator new (size_t size)
 void Vector::operator delete (void *p)
 {
 	p = util::free(p);
+}
+
+void Vector::txt (void *stream) const
+{
+	FILE *f = (FILE*) stream;
+	fprintf(f, "%.15e %.15e %.15e ", this->x, this->y, this->z);
 }
 
 /*


### PR DESCRIPTION
NOTES:
- adds txt() method to the constituents of particle
- adds global time-step for logging so that we can determine how often we export data
- compiles with g++-10 and higher
- valgrind reports no memory issues