### PR TITLE
exports global time-step for logging

### DIFF
--- a/src/logger/Logger.cpp
+++ b/src/logger/Logger.cpp
@@ -39,6 +39,7 @@ void Logger::params () const
 	fprintf(*f, "GLOBAL_TIME_START: %.15e\n", GLOBAL_TIME_START);
 	fprintf(*f, "GLOBAL_TIME_END: %.15e\n", GLOBAL_TIME_END);
 	fprintf(*f, "GLOBAL_TIME_STEP: %.15e\n", GLOBAL_TIME_STEP);
+	fprintf(*f, "GLOBAL_TIME_STEP_LOGGER: %.15e\n", GLOBAL_TIME_STEP_LOGGER);
 	fprintf(*f, "SYSTEM_BOX_LENGTH: %.15e\n", bb->length());
 	fprintf(*f, "SYSTEM_BOX_WIDTH: %.15e\n", bb->width());
 	fprintf(*f, "SYSTEM_BOX_HEIGHT: %.15e\n", bb->height());


### PR DESCRIPTION
NOTE:
we need this for post-processing since from it we can determine the number of data files present in the filesystem upon completion of the simulation