### PR TITLE
scales Brownian mobility based on particle size

### DIFF
--- a/include/Particle.h
+++ b/include/Particle.h
@@ -18,7 +18,9 @@ struct Particle : BDXObject
 	List *list = NULL;
 	ID *id = NULL;
 	Kind *kind = NULL;
-	double _radius_ = 1.0;
+	double __radius__ = 1.0;
+	double __translational_mobility_scaling__ = 1.0;
+	double __rotational_mobility_scaling__ = 1.0;
 	Particle(Vector *r,
 		 Vector *u,
 		 Vector *E,
@@ -32,6 +34,8 @@ struct Particle : BDXObject
 	virtual void ia(const Particle *particle) = 0;
 	void *operator new(size_t size);
 	void operator delete(void *p);
+	double _rotational_mobility_scaling_() const;
+	double _translational_mobility_scaling_() const;
 	void _updatePositionVectorComponent_(double *x,
 					     double const F_x,
 					     double const mobility);

--- a/src/particle/Particle.cpp
+++ b/src/particle/Particle.cpp
@@ -27,7 +27,9 @@ Particle::Particle (Vector *r,
 	this->list = list;
 	this->id = id;
 	this->kind = kind;
-	this->_radius_ = a;
+	this->__radius__ = a;
+	this->__rotational_mobility_scaling__= (1.0 / sqrt(a * a * a));
+	this->__translational_mobility_scaling__ = (1.0 / sqrt(a));
 }
 
 void *Particle::operator new (size_t size)
@@ -40,9 +42,14 @@ void Particle::operator delete (void *p)
 	p = util::free(p);
 }
 
-double Particle::radius () const
+double Particle::_rotational_mobility_scaling_() const
 {
-	return this->_radius_;
+	return this->__rotational_mobility_scaling__;
+}
+
+double Particle::_translational_mobility_scaling_() const
+{
+	return this->__translational_mobility_scaling__;
 }
 
 void Particle::_updatePositionVectorComponent_ (double *x,
@@ -75,8 +82,12 @@ void Particle::_rotate_ (double const mobility)
 void Particle::BrownianMotion ()
 {
 	constexpr double dt = GLOBAL_TIME_STEP;
-	constexpr double translational_mobility = sqrt(2.0 * dt);
-	constexpr double rotational_mobility = sqrt(1.5 * dt);
+	constexpr double translational_mobility_base = sqrt(2.0 * dt);
+	constexpr double rotational_mobility_base = sqrt(1.5 * dt);
+	double const translational_mobility = (this->_translational_mobility_scaling_() *
+					       translational_mobility_base);
+	double const rotational_mobility = (this->_rotational_mobility_scaling_() *
+					    rotational_mobility_base);
 	this->_translate_(translational_mobility);
 	this->_rotate_(rotational_mobility);
 }
@@ -93,6 +104,11 @@ void Particle::txt (void *stream) const
 	this->F->txt(stream);
 	this->T->txt(stream);
 	fprintf(f, "%.15e \n", this->radius());
+}
+
+double Particle::radius () const
+{
+	return this->__radius__;
 }
 
 /*

--- a/src/test/util/test.cpp
+++ b/src/test/util/test.cpp
@@ -829,7 +829,7 @@ void tutil20 (void)
 /*
 
 void tutil21(void)
-- imports LAMMPS (unit) spheres data
+- imports LAMMPS spheres data
 - performs a 15 minute simulation test run
 - checks that no particle is outside the system boundaries when the BDX simulation ends
 - dumps the particle and simulation data to plain text file
@@ -875,7 +875,8 @@ void tutil21 (void)
 	size_t const num_particles = lmp::parse(data, stack);
 	const double **it = (const double**) stack->begin();
 	for (size_t i = 0; i != num_particles; ++i) {
-		double const a = 1.0;
+		// we can double the radius `a' because the spheres are non-interacting
+		double const a = 2.0;
 		ID *id = new ID(i);
 		Kind *kind = new Kind(SPHERE);
 


### PR DESCRIPTION
NOTES:
the equations of motion are non-dimensionalized with respect to the unit sphere, this commit accounts for different sphere radii

the MSD results confirms the scaling (not committed though you can verify this yourself by running the BDX app tests and the MSD scripts.)

the scaling factor is computed upon object construction for speed during the simulation (we don't want to spend time computing the costly squared roots)

equations for the MSD:

MSD translation: (2 / a) * t
MSD rotation: (1.5 / a^3) * t

where `t` has been non-dimensionalized with the translational diffusivity of the unit sphere and radius in the usual way, and `a` is the non-dimensional sphere radius