### PR TITLE
adds vector cross product computation

### DIFF
--- a/include/Vector.h
+++ b/include/Vector.h
@@ -14,6 +14,10 @@ struct Vector {
 	void unit();
 };
 
+namespace vector {
+	void cross(Vector *w, const Vector *u, const Vector *v);
+};
+
 #endif
 
 /*

--- a/src/vector/Vector.cpp
+++ b/src/vector/Vector.cpp
@@ -46,6 +46,13 @@ void Vector::unit ()
 	this->z /= norm;
 }
 
+void vector::cross (Vector *w, const Vector *u, const Vector *v)
+{
+	w->x = ((u->y * v->z) - (u->z * v->y));
+	w->y = ((u->z * v->x) - (u->x * v->z));
+	w->z = ((u->x * v->y) - (u->y * v->x));
+}
+
 /*
 
 BDX                                             December 31, 2023


### PR DESCRIPTION
NOTES:
we don't want to define an operator and we also do not want to return a vector to avoid the memory allocation overhead