### PR TITLE
adheres to conventions

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -5,11 +5,9 @@ struct BDX;
 
 struct Config
 {
-	private:
 	void *_json_ = NULL;
 	void *_objects_ = NULL;
-	void Box(void *vobject);
-	public:
+	void _Box_(void *vobject);
 	BDX *app = NULL;
 	Config();
 	void bind(BDX *app);

--- a/include/Config.h
+++ b/include/Config.h
@@ -5,8 +5,8 @@ struct BDX;
 
 struct Config
 {
-	void *_json_ = NULL;
-	void *_objects_ = NULL;
+	void *__json__ = NULL;
+	void *__objects__ = NULL;
 	void _Box_(void *vobject);
 	BDX *app = NULL;
 	Config();

--- a/include/Integrator.h
+++ b/include/Integrator.h
@@ -5,9 +5,7 @@ struct BDX;
 
 struct Integrator
 {
-	private:
 	BDX *app = NULL;
-	public:
 	Integrator();
 	void bind(BDX *app);
 	void *operator new(size_t size);

--- a/include/Stack.h
+++ b/include/Stack.h
@@ -3,12 +3,12 @@
 
 struct Stack
 {
-	void **_stack_ = NULL;
-	void **_begin_ = NULL;
-	void **_avail_ = NULL;
-	void **_limit_ = NULL;
-	size_t _allot_ = 8;
-	size_t _size_ = 0;
+	void **__stack__ = NULL;
+	void **__begin__ = NULL;
+	void **__avail__ = NULL;
+	void **__limit__ = NULL;
+	size_t __allot__ = 8;
+	size_t __size__ = 0;
 	void _init_();
 	void *_copy_() const;
 	size_t _bytes_ () const;

--- a/include/Stack.h
+++ b/include/Stack.h
@@ -3,18 +3,16 @@
 
 struct Stack
 {
-	private:
 	void **_stack_ = NULL;
 	void **_begin_ = NULL;
 	void **_avail_ = NULL;
 	void **_limit_ = NULL;
 	size_t _allot_ = 8;
 	size_t _size_ = 0;
-	void init();
-	void *copy() const;
-	size_t bytes () const;
-	void grow();
-	public:
+	void _init_();
+	void *_copy_() const;
+	size_t _bytes_ () const;
+	void _grow_();
 	Stack(void);
 	size_t cap() const;
 	size_t numel() const;

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -323,7 +323,7 @@ void Config::parse ()
 	this->_objects_ = (void*) objects;
 }
 
-void Config::Box (void *vobject)
+void Config::_Box_ (void *vobject)
 {
 	Object *object = (Object*) vobject;
 	ObjectStack *ostack = object->ostack;
@@ -359,7 +359,7 @@ void Config::config ()
 		const Object *object = *iter;
 		if (!strcmp(object->key, "Box")) {
 			void *vobject = (void*) object;
-			this->Box(vobject);
+			this->_Box_(vobject);
 			continue;
 		}
 	}

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -303,12 +303,12 @@ void Config::load ()
 	Cfg_SizeJSON(f);
 	void *json = Cfg_ReadJSON(f);
 	Cfg_CloseJSON(f);
-	this->_json_= json;
+	this->__json__= json;
 }
 
 void Config::parse ()
 {
-	const char *JSON = (const char*) this->_json_;
+	const char *JSON = (const char*) this->__json__;
 	const char *json[] = {JSON};
 	if (!Cfg_Parse(json)) {
 		util::clearall();
@@ -320,7 +320,7 @@ void Config::parse ()
 	ObjectStack *objects = new ObjectStack(stack);
 
 	Cfg_AddObjects(objects, json);
-	this->_objects_ = (void*) objects;
+	this->__objects__ = (void*) objects;
 }
 
 void Config::_Box_ (void *vobject)
@@ -354,7 +354,7 @@ void Config::_Box_ (void *vobject)
 
 void Config::config ()
 {
-	ObjectStack *ostack = (ObjectStack*) this->_objects_;
+	ObjectStack *ostack = (ObjectStack*) this->__objects__;
 	for (const Object **iter = ostack->begin(); iter != ostack->end(); ++iter) {
 		const Object *object = *iter;
 		if (!strcmp(object->key, "Box")) {

--- a/src/stack/Stack.cpp
+++ b/src/stack/Stack.cpp
@@ -39,10 +39,6 @@ void Stack::clear ()
 	if (!this->__stack__) {
 		return;
 	}
-
-	void *vstack = (void*) this->__stack__;
-	size_t const bytes = this->_bytes_();
-	memset(vstack, 0, bytes);
 	this->__avail__ = this->__begin__;
 	this->__size__ = 0;
 }

--- a/src/stack/Stack.cpp
+++ b/src/stack/Stack.cpp
@@ -67,12 +67,10 @@ void Stack::_grow_ ()
 {
 	void *data = this->_copy_();
 	size_t const numel = this->numel();
+	size_t const bytes = this->_bytes_();
 	size_t const allot = 2 * numel;
 	void **stack = create(allot);
-
-	void *vstack = (void*) stack;
-	size_t const size = numel * sizeof(void*);
-	memcpy(vstack, data, size);
+	memcpy(stack, data, bytes);
 	data = util::free(data);
 
 	this->__stack__ = stack;

--- a/src/stack/Stack.cpp
+++ b/src/stack/Stack.cpp
@@ -29,7 +29,7 @@ size_t Stack::numel () const
 	return (this->_avail_ - this->_begin_);
 }
 
-size_t Stack::bytes () const
+size_t Stack::_bytes_ () const
 {
 	return this->_size_;
 }
@@ -41,7 +41,7 @@ void Stack::clear ()
 	}
 
 	void *vstack = (void*) this->_stack_;
-	size_t const bytes = this->bytes();
+	size_t const bytes = this->_bytes_();
 	memset(vstack, 0, bytes);
 	this->_avail_ = this->_begin_;
 	this->_size_ = 0;
@@ -57,7 +57,7 @@ void **Stack::end ()
 	return this->_avail_;
 }
 
-void *Stack::copy () const
+void *Stack::_copy_ () const
 {
 	size_t const numel = this->numel();
 	size_t const size = numel * sizeof(void*);
@@ -67,9 +67,9 @@ void *Stack::copy () const
 	return dst;
 }
 
-void Stack::grow ()
+void Stack::_grow_ ()
 {
-	void *data = Stack::copy();
+	void *data = Stack::_copy_();
 	size_t const numel = this->numel();
 	size_t const allot = 2 * numel;
 	void **stack = create(allot);
@@ -86,7 +86,7 @@ void Stack::grow ()
 	this->_allot_ = allot;
 }
 
-void Stack::init ()
+void Stack::_init_ ()
 {
 	this->_stack_ = create(this->_allot_);
 	this->_begin_ = this->_stack_;
@@ -97,11 +97,11 @@ void Stack::init ()
 void Stack::add (void *elem)
 {
 	if (!this->_stack_) {
-		Stack::init();
+		Stack::_init_();
 	}
 
 	if (this->_avail_ == this->_limit_) {
-		grow();
+		_grow_();
 	}
 
 	*this->_avail_ = elem;

--- a/src/stack/Stack.cpp
+++ b/src/stack/Stack.cpp
@@ -69,7 +69,7 @@ void *Stack::_copy_ () const
 
 void Stack::_grow_ ()
 {
-	void *data = Stack::_copy_();
+	void *data = this->_copy_();
 	size_t const numel = this->numel();
 	size_t const allot = 2 * numel;
 	void **stack = create(allot);
@@ -97,11 +97,11 @@ void Stack::_init_ ()
 void Stack::add (void *elem)
 {
 	if (!this->_stack_) {
-		Stack::_init_();
+		this->_init_();
 	}
 
 	if (this->_avail_ == this->_limit_) {
-		_grow_();
+		this->_grow_();
 	}
 
 	*this->_avail_ = elem;

--- a/src/stack/Stack.cpp
+++ b/src/stack/Stack.cpp
@@ -21,40 +21,40 @@ Stack::Stack (void)
 
 size_t Stack::cap () const
 {
-	return (this->_limit_ - this->_begin_);
+	return (this->__limit__ - this->__begin__);
 }
 
 size_t Stack::numel () const
 {
-	return (this->_avail_ - this->_begin_);
+	return (this->__avail__ - this->__begin__);
 }
 
 size_t Stack::_bytes_ () const
 {
-	return this->_size_;
+	return this->__size__;
 }
 
 void Stack::clear ()
 {
-	if (!this->_stack_) {
+	if (!this->__stack__) {
 		return;
 	}
 
-	void *vstack = (void*) this->_stack_;
+	void *vstack = (void*) this->__stack__;
 	size_t const bytes = this->_bytes_();
 	memset(vstack, 0, bytes);
-	this->_avail_ = this->_begin_;
-	this->_size_ = 0;
+	this->__avail__ = this->__begin__;
+	this->__size__ = 0;
 }
 
 void **Stack::begin ()
 {
-	return this->_begin_;
+	return this->__begin__;
 }
 
 void **Stack::end ()
 {
-	return this->_avail_;
+	return this->__avail__;
 }
 
 void *Stack::_copy_ () const
@@ -62,7 +62,7 @@ void *Stack::_copy_ () const
 	size_t const numel = this->numel();
 	size_t const size = numel * sizeof(void*);
 	void *dst = util::malloc(size);
-	const void *src = ((const void*) this->_stack_);
+	const void *src = ((const void*) this->__stack__);
 	memcpy(dst, src, size);
 	return dst;
 }
@@ -79,34 +79,34 @@ void Stack::_grow_ ()
 	memcpy(vstack, data, size);
 	data = util::free(data);
 
-	this->_stack_ = stack;
-	this->_begin_ = stack;
-	this->_avail_ = stack + numel;
-	this->_limit_ = stack + allot;
-	this->_allot_ = allot;
+	this->__stack__ = stack;
+	this->__begin__ = stack;
+	this->__avail__ = stack + numel;
+	this->__limit__ = stack + allot;
+	this->__allot__ = allot;
 }
 
 void Stack::_init_ ()
 {
-	this->_stack_ = create(this->_allot_);
-	this->_begin_ = this->_stack_;
-	this->_avail_ = this->_stack_;
-	this->_limit_ = this->_stack_ + this->_allot_;
+	this->__stack__ = create(this->__allot__);
+	this->__begin__ = this->__stack__;
+	this->__avail__ = this->__stack__;
+	this->__limit__ = this->__stack__ + this->__allot__;
 }
 
 void Stack::add (void *elem)
 {
-	if (!this->_stack_) {
+	if (!this->__stack__) {
 		this->_init_();
 	}
 
-	if (this->_avail_ == this->_limit_) {
+	if (this->__avail__ == this->__limit__) {
 		this->_grow_();
 	}
 
-	*this->_avail_ = elem;
-	++this->_avail_;
-	this->_size_ += sizeof(void*);
+	*this->__avail__ = elem;
+	++this->__avail__;
+	this->__size__ += sizeof(void*);
 }
 
 void *Stack::operator new (size_t size)


### PR DESCRIPTION
- we now let `structs` have `public` data and function members (the default)
- we also now adopt Python's way of naming elements of a `struct` that are part of its implementation instead of hiding these elements by making them `private`

in the end this simplifies the development and we are not writing a library so that we need to worry about users modifying elements that they shouldn't