### PR TITLE
removes redundant typedef `kind_t`

### DIFF
--- a/include/Kind.h
+++ b/include/Kind.h
@@ -1,21 +1,21 @@
 #ifndef GUARD_BDX_KIND_H
 #define GUARD_BDX_KIND_H
 
-typedef enum {
+enum kind {
 	SPHERE,
 	JANUS,
 	SPHEROID,
 	CHIRAL
-} kind_t;
+};
 
 struct Kind
 {
-	kind_t kind;
+	enum kind kind;
 	Kind();
-	Kind(kind_t const kind);
-	kind_t k(void) const;
+	Kind(enum kind const kind);
+	enum kind k(void) const;
 	static const char *stringify(const Kind *kind);
-	static kind_t enumerator(const char *kind);
+	static enum kind enumerator(const char *kind);
 	void *operator new(size_t size);
 	void operator delete(void *p);
 	void txt(void *stream) const;

--- a/src/chiral/Chiral.cpp
+++ b/src/chiral/Chiral.cpp
@@ -35,16 +35,16 @@ void Chiral::ia (const Particle *particle)
 	const Kind *kind = that->kind;
 	enum kind const k = kind->k();
 	switch(k){
-		case SPHERE:
+		case kind::SPHERE:
 		os::print("chiral-sphere interaction\n");
 		break;
-		case JANUS:
+		case kind::JANUS:
 		os::print("chiral-janus interaction\n");
 		break;
-		case SPHEROID:
+		case kind::SPHEROID:
 		os::print("chiral-spheroid interaction\n");
 		break;
-		case CHIRAL:
+		case kind::CHIRAL:
 		os::print("chiral-chiral interaction\n");
 		break;
 		default:

--- a/src/chiral/Chiral.cpp
+++ b/src/chiral/Chiral.cpp
@@ -33,7 +33,7 @@ void Chiral::ia (const Particle *particle)
 {
 	const Particle *that = particle;
 	const Kind *kind = that->kind;
-	kind_t const k = kind->k();
+	enum kind const k = kind->k();
 	switch(k){
 		case SPHERE:
 		os::print("chiral-sphere interaction\n");

--- a/src/janus/Janus.cpp
+++ b/src/janus/Janus.cpp
@@ -25,7 +25,7 @@ void Janus::ia (const Particle *particle)
 {
 	const Particle *that = particle;
 	const Kind *kind = that->kind;
-	kind_t const k = kind->k();
+	enum kind const k = kind->k();
 	switch(k){
 		case SPHERE:
 		os::print("janus-sphere interaction\n");

--- a/src/janus/Janus.cpp
+++ b/src/janus/Janus.cpp
@@ -27,16 +27,16 @@ void Janus::ia (const Particle *particle)
 	const Kind *kind = that->kind;
 	enum kind const k = kind->k();
 	switch(k){
-		case SPHERE:
+		case kind::SPHERE:
 		os::print("janus-sphere interaction\n");
 		break;
-		case JANUS:
+		case kind::JANUS:
 		os::print("janus-janus interaction\n");
 		break;
-		case SPHEROID:
+		case kind::SPHEROID:
 		os::print("janus-spheroid interaction\n");
 		break;
-		case CHIRAL:
+		case kind::CHIRAL:
 		os::print("janus-chiral interaction\n");
 		break;
 		default:

--- a/src/kind/Kind.cpp
+++ b/src/kind/Kind.cpp
@@ -23,13 +23,13 @@ const char *Kind::stringify (const Kind *kind)
 {
 	enum kind const k = kind->k();
 	switch(k) {
-		case SPHERE:
+		case kind::SPHERE:
 			return "Sphere";
-		case JANUS:
+		case kind::JANUS:
 			return "Janus";
-		case SPHEROID:
+		case kind::SPHEROID:
 			return "Spheroid";
-		case CHIRAL:
+		case kind::CHIRAL:
 			return "Chiral";
 		default:
 			return "";
@@ -39,19 +39,19 @@ const char *Kind::stringify (const Kind *kind)
 enum kind Kind::enumerator (const char *kind)
 {
 	if (!strcmp(kind, "Sphere")) {
-		return SPHERE;
+		return kind::SPHERE;
 	}
 
 	if (!strcmp(kind, "Janus")) {
-		return JANUS;
+		return kind::JANUS;
 	}
 
 	if (!strcmp(kind, "Spheroid")) {
-		return SPHEROID;
+		return kind::SPHEROID;
 	}
 
 	if (!strcmp(kind, "Chiral")) {
-		return CHIRAL;
+		return kind::CHIRAL;
 	}
 
 	enum kind unknown = ((enum kind) -1);

--- a/src/kind/Kind.cpp
+++ b/src/kind/Kind.cpp
@@ -4,24 +4,24 @@
 #include "util.h"
 #include "Kind.h"
 
-Kind::Kind () : kind(SPHERE)
+Kind::Kind () : kind(kind::SPHERE)
 {
 	return;
 }
 
-Kind::Kind (kind_t const kind) : kind(kind)
+Kind::Kind (enum kind const kind) : kind(kind)
 {
 	return;
 }
 
-kind_t Kind::k() const
+enum kind Kind::k() const
 {
 	return this->kind;
 }
 
 const char *Kind::stringify (const Kind *kind)
 {
-	kind_t const k = kind->k();
+	enum kind const k = kind->k();
 	switch(k) {
 		case SPHERE:
 			return "Sphere";
@@ -36,7 +36,7 @@ const char *Kind::stringify (const Kind *kind)
 	}
 }
 
-kind_t Kind::enumerator (const char *kind)
+enum kind Kind::enumerator (const char *kind)
 {
 	if (!strcmp(kind, "Sphere")) {
 		return SPHERE;
@@ -54,7 +54,7 @@ kind_t Kind::enumerator (const char *kind)
 		return CHIRAL;
 	}
 
-	kind_t unknown = ((kind_t) -1);
+	enum kind unknown = ((enum kind) -1);
 	return unknown;
 }
 

--- a/src/sphere/Sphere.cpp
+++ b/src/sphere/Sphere.cpp
@@ -27,16 +27,16 @@ void Sphere::ia (const Particle *particle)
 	const Kind *kind = that->kind;
 	enum kind const k = kind->k();
 	switch(k){
-		case SPHERE:
+		case kind::SPHERE:
 		os::print("sphere-sphere interaction\n");
 		break;
-		case JANUS:
+		case kind::JANUS:
 		os::print("sphere-janus interaction\n");
 		break;
-		case SPHEROID:
+		case kind::SPHEROID:
 		os::print("sphere-spheroid interaction\n");
 		break;
-		case CHIRAL:
+		case kind::CHIRAL:
 		os::print("sphere-chiral interaction\n");
 		break;
 		default:

--- a/src/sphere/Sphere.cpp
+++ b/src/sphere/Sphere.cpp
@@ -25,7 +25,7 @@ void Sphere::ia (const Particle *particle)
 {
 	const Particle *that = particle;
 	const Kind *kind = that->kind;
-	kind_t const k = kind->k();
+	enum kind const k = kind->k();
 	switch(k){
 		case SPHERE:
 		os::print("sphere-sphere interaction\n");

--- a/src/spheroid/Spheroid.cpp
+++ b/src/spheroid/Spheroid.cpp
@@ -40,16 +40,16 @@ void Spheroid::ia (const Particle *particle)
 	const Kind *kind = that->kind;
 	enum kind const k = kind->k();
 	switch(k){
-		case SPHERE:
+		case kind::SPHERE:
 		os::print("spheroid-sphere interaction\n");
 		break;
-		case JANUS:
+		case kind::JANUS:
 		os::print("spheroid-janus interaction\n");
 		break;
-		case SPHEROID:
+		case kind::SPHEROID:
 		os::print("spheroid-spheroid interaction\n");
 		break;
-		case CHIRAL:
+		case kind::CHIRAL:
 		os::print("spheroid-chiral interaction\n");
 		break;
 		default:

--- a/src/spheroid/Spheroid.cpp
+++ b/src/spheroid/Spheroid.cpp
@@ -38,7 +38,7 @@ void Spheroid::ia (const Particle *particle)
 {
 	const Particle *that = particle;
 	const Kind *kind = that->kind;
-	kind_t const k = kind->k();
+	enum kind const k = kind->k();
 	switch(k){
 		case SPHERE:
 		os::print("spheroid-sphere interaction\n");

--- a/src/test/util/test.cpp
+++ b/src/test/util/test.cpp
@@ -130,19 +130,19 @@ Particle *_Particle (Vector *r,
 	enum kind const k = kind->k();
 	switch(k)
 	{
-		case SPHERE:
+		case kind::SPHERE:
 		particle = new Sphere(r, u, E, d, F, T, list, id, kind, a);
 		break;
 
-		case JANUS:
+		case kind::JANUS:
 		particle = new Janus(r, u, E, d, F, T, list, id, kind, a);
 		break;
 
-		case SPHEROID:
+		case kind::SPHEROID:
 		particle = new Spheroid(r, u, E, d, F, T, list, id, kind, a, b);
 		break;
 
-		case CHIRAL:
+		case kind::CHIRAL:
 		particle = new Chiral(r, u, E, d, F, T, list, id, kind, a, b, c);
 		break;
 
@@ -786,7 +786,7 @@ void tutil19 (void)
 	for (size_t i = 0; i != num_particles; ++i) {
 		double const a = 1.0;
 		ID *id = new ID(i);
-		Kind *kind = new Kind(SPHERE);
+		Kind *kind = new Kind(kind::SPHERE);
 
 		it += 2; // skips LAMMPS ID and Group
 
@@ -878,7 +878,7 @@ void tutil21 (void)
 		// we can double the radius `a' because the spheres are non-interacting
 		double const a = 2.0;
 		ID *id = new ID(i);
-		Kind *kind = new Kind(SPHERE);
+		Kind *kind = new Kind(kind::SPHERE);
 
 		it += 2; // skips LAMMPS ID and Group
 

--- a/src/test/util/test.cpp
+++ b/src/test/util/test.cpp
@@ -127,7 +127,7 @@ Particle *_Particle (Vector *r,
 		     double const c)
 {
 	Particle *particle = NULL;
-	kind_t const k = kind->k();
+	enum kind const k = kind->k();
 	switch(k)
 	{
 		case SPHERE:
@@ -355,7 +355,7 @@ void tutil11 (void)
 		double const min_k = 0;
 		double const max_k = 4;
 		double const k = min_k + (max_k - min_k) * (rand() / ((double) RAND_MAX));
-		Kind *kind = new Kind((kind_t) k);
+		Kind *kind = new Kind((enum kind) k);
 		double const x = rand();
 		double const y = rand();
 		double const z = rand();
@@ -403,7 +403,7 @@ void tutil11 (void)
 		double const min_k = 0;
 		double const max_k = 4;
 		double const k = min_k + (max_k - min_k) * (rand() / ((double) RAND_MAX));
-		Kind *kind = new Kind((kind_t) k);
+		Kind *kind = new Kind((enum kind) k);
 		double const x = rand();
 		double const y = rand();
 		double const z = rand();
@@ -438,7 +438,7 @@ void tutil12 (void)
 		double const min_k = 0;
 		double const max_k = 4;
 		double const k = min_k + (max_k - min_k) * (rand() / ((double) RAND_MAX));
-		Kind *kind = new Kind((kind_t) k);
+		Kind *kind = new Kind((enum kind) k);
 		double const x = rand();
 		double const y = rand();
 		double const z = rand();
@@ -489,7 +489,7 @@ void tutil12 (void)
 		double const min_k = 0;
 		double const max_k = 4;
 		double const k = min_k + (max_k - min_k) * (rand() / ((double) RAND_MAX));
-		Kind *kind = new Kind((kind_t) k);
+		Kind *kind = new Kind((enum kind) k);
 		double const x = rand();
 		double const y = rand();
 		double const z = rand();
@@ -525,7 +525,7 @@ void tutil13 (void)
 		double const min_k = 0;
 		double const max_k = 4;
 		double const k = min_k + (max_k - min_k) * (rand() / ((double) RAND_MAX));
-		Kind *kind = new Kind((kind_t) k);
+		Kind *kind = new Kind((enum kind) k);
 		double const x = rand();
 		double const y = rand();
 		double const z = rand();
@@ -565,7 +565,7 @@ void tutil13 (void)
 		double const min_k = 0;
 		double const max_k = 4;
 		double const k = min_k + (max_k - min_k) * (rand() / ((double) RAND_MAX));
-		Kind *kind = new Kind((kind_t) k);
+		Kind *kind = new Kind((enum kind) k);
 		double const x = rand();
 		double const y = rand();
 		double const z = rand();


### PR DESCRIPTION
by removing it we can now have these enums scoped as `kind::SPHERE`, `kind::JANUS`, etc.