### PR TITLE
adds particle interaction-range table

### DIFF
--- a/include/Kind.h
+++ b/include/Kind.h
@@ -5,7 +5,8 @@ enum kind {
 	SPHERE,
 	JANUS,
 	SPHEROID,
-	CHIRAL
+	CHIRAL,
+	NUM_ENUM_KIND
 };
 
 struct Kind

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -5,6 +5,7 @@
 
 #include "os.h"
 #include "util.h"
+#include "Kind.h"
 #include "Stack.h"
 #include "BDXObject.h"
 #include "BoundingBox.h"
@@ -13,6 +14,9 @@
 #include "BDX.h"
 
 #define MAX_FIELD_NAME_SIZE 80
+
+static double particle_interaction_range_table[kind::NUM_ENUM_KIND][kind::NUM_ENUM_KIND];
+static double (*pirtbl)[][kind::NUM_ENUM_KIND] = &particle_interaction_range_table;
 
 struct Object;
 
@@ -98,7 +102,8 @@ void ObjectStack::operator delete (void *p)
 
 Config::Config ()
 {
-	return;
+	// sets default sphere-sphere interaction range, user can override via config.json
+	(*pirtbl)[kind::SPHERE][kind::SPHERE] = 1.5;
 }
 
 void Config::bind (BDX *app)


### PR DESCRIPTION
NOTES:
The table defines the particle-particle interaction range given the kinds of the pair. Pairs beyond the interaction range experience a zero force from one another.

Adds only for spheres since it is the kind that I am currently working in earnest.

adds another entry to `enum kind` for the purposes of knowing how many enums have been defined; based on stackoverflow there's no consensus on what's the best approach so I picked the one that I fancied. (Maybe some cool feature shall be added to C++ that solves this in a more elegant manner but for now this is "good enough" for this case.)