### PR TITLE
adds utils to access the particle interaction ranges

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -1,7 +1,13 @@
 #ifndef GUARD_BDX_CONFIG_H
 #define GUARD_BDX_CONFIG_H
 
+struct Particle;
 struct BDX;
+
+namespace config {
+	double particleInteractionRange(const Particle *p1, const Particle *p2);
+	double particleExtendedInteractionRange(const Particle *p1, const Particle *p2);
+};
 
 struct Config
 {

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -15,6 +15,7 @@
 
 #define MAX_FIELD_NAME_SIZE 80
 
+// particle (extended) interaction range tables for Verlet-list building
 static double part_interact_range_table[kind::NUM_ENUM_KIND][kind::NUM_ENUM_KIND];
 static double part_ext_interact_range_table[kind::NUM_ENUM_KIND][kind::NUM_ENUM_KIND];
 static double (*pirtbl)[][kind::NUM_ENUM_KIND] = &part_interact_range_table;

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -9,6 +9,7 @@
 #include "Stack.h"
 #include "BDXObject.h"
 #include "BoundingBox.h"
+#include "Particle.h"
 #include "Config.h"
 #include "System.h"
 #include "BDX.h"
@@ -372,6 +373,16 @@ void Config::config ()
 			continue;
 		}
 	}
+}
+
+double config::particleInteractionRange(const Particle *p1, const Particle *p2)
+{
+	return (*pirtbl)[p1->kind->k()][p2->kind->k()];
+}
+
+double config::particleExtendedInteractionRange(const Particle *p1, const Particle *p2)
+{
+	return (*pxirtbl)[p1->kind->k()][p2->kind->k()];
 }
 
 /*

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -16,7 +16,9 @@
 #define MAX_FIELD_NAME_SIZE 80
 
 static double particle_interaction_range_table[kind::NUM_ENUM_KIND][kind::NUM_ENUM_KIND];
+static double particle_extended_interaction_range_table[kind::NUM_ENUM_KIND][kind::NUM_ENUM_KIND];
 static double (*pirtbl)[][kind::NUM_ENUM_KIND] = &particle_interaction_range_table;
+static double (*pxirtbl)[][kind::NUM_ENUM_KIND] = &particle_extended_interaction_range_table;
 
 struct Object;
 
@@ -104,6 +106,7 @@ Config::Config ()
 {
 	// sets default sphere-sphere interaction range, user can override via config.json
 	(*pirtbl)[kind::SPHERE][kind::SPHERE] = 1.5;
+	(*pxirtbl)[kind::SPHERE][kind::SPHERE] = 2.0;
 }
 
 void Config::bind (BDX *app)

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -15,10 +15,10 @@
 
 #define MAX_FIELD_NAME_SIZE 80
 
-static double particle_interaction_range_table[kind::NUM_ENUM_KIND][kind::NUM_ENUM_KIND];
-static double particle_extended_interaction_range_table[kind::NUM_ENUM_KIND][kind::NUM_ENUM_KIND];
-static double (*pirtbl)[][kind::NUM_ENUM_KIND] = &particle_interaction_range_table;
-static double (*pxirtbl)[][kind::NUM_ENUM_KIND] = &particle_extended_interaction_range_table;
+static double part_interact_range_table[kind::NUM_ENUM_KIND][kind::NUM_ENUM_KIND];
+static double part_ext_interact_range_table[kind::NUM_ENUM_KIND][kind::NUM_ENUM_KIND];
+static double (*pirtbl)[][kind::NUM_ENUM_KIND] = &part_interact_range_table;
+static double (*pxirtbl)[][kind::NUM_ENUM_KIND] = &part_ext_interact_range_table;
 
 struct Object;
 

--- a/src/test/util/test.cpp
+++ b/src/test/util/test.cpp
@@ -616,7 +616,7 @@ void tutil15 (void)
 	Handler *handler = new Handler(stack);
 	System *system = new System(bb, Brownian, handler);
 	Prompt *prompt = new Prompt();
-	Config *config = new Config();
+	Config *cfg = new Config();
 	Timer *timer = new Timer();
 	Random *random = new Random(random::NORMAL);
 	Looper *looper = new Looper();
@@ -624,7 +624,7 @@ void tutil15 (void)
 	Integrator *integrator = new Integrator();
 	Logger *logger = new Logger();
 	BDX *App = new BDX(prompt,
-			   config,
+			   cfg,
 			   timer,
 			   random,
 			   looper,
@@ -633,9 +633,9 @@ void tutil15 (void)
 			   logger,
 			   system);
 
-	config->load();
-	config->parse();
-	config->config();
+	cfg->load();
+	cfg->parse();
+	cfg->config();
 	delete(App);
 	util::clearall();
 }
@@ -653,7 +653,7 @@ void tutil16 (void)
 	Handler *handler = new Handler(stack);
 	System *system = new System(bb, Brownian, handler);
 	Prompt *prompt = new Prompt();
-	Config *config = new Config();
+	Config *cfg = new Config();
 	Timer *timer = new Timer();
 	Random *random = new Random(random::NORMAL);
 	Looper *looper = new Looper();
@@ -661,7 +661,7 @@ void tutil16 (void)
 	Integrator *integrator = new Integrator();
 	Logger *logger = new Logger();
 	BDX *App = new BDX(prompt,
-			   config,
+			   cfg,
 			   timer,
 			   random,
 			   looper,
@@ -670,9 +670,9 @@ void tutil16 (void)
 			   logger,
 			   system);
 
-	config->load();
-	config->parse();
-	config->config();
+	cfg->load();
+	cfg->parse();
+	cfg->config();
 	App->_exec_ = true;
 	App->looper->loop();
 	util::clearall();
@@ -758,7 +758,7 @@ void tutil19 (void)
 	Handler *handler = new Handler(stack);
 	System *system = new System(bb, Brownian, handler);
 	Prompt *prompt = new Prompt();
-	Config *config = new Config();
+	Config *cfg = new Config();
 	Timer *timer = new Timer();
 	Random *random = new Random(random::NORMAL);
 	Looper *looper = new Looper();
@@ -766,7 +766,7 @@ void tutil19 (void)
 	Integrator *integrator = new Integrator();
 	Logger *logger = new Logger();
 	BDX *App = new BDX(prompt,
-			   config,
+			   cfg,
 			   timer,
 			   random,
 			   looper,
@@ -775,9 +775,9 @@ void tutil19 (void)
 			   logger,
 			   system);
 
-	config->load();
-	config->parse();
-	config->config();
+	cfg->load();
+	cfg->parse();
+	cfg->config();
 
 	stack = new Stack();
 	void *data = lmp::load();
@@ -847,7 +847,7 @@ void tutil21 (void)
 	Handler *handler = new Handler(new Stack());
 	System *system = new System(bb, Brownian, handler);
 	Prompt *prompt = new Prompt();
-	Config *config = new Config();
+	Config *cfg = new Config();
 	time_t const walltime = 15 * 60;
 	Timer *timer = new Timer(walltime);
 	Random *random = new Random(random::NORMAL);
@@ -856,7 +856,7 @@ void tutil21 (void)
 	Integrator *integrator = new Integrator();
 	Logger *logger = new Logger();
 	BDX *App = new BDX(prompt,
-			   config,
+			   cfg,
 			   timer,
 			   random,
 			   looper,
@@ -866,9 +866,9 @@ void tutil21 (void)
 			   system);
 
 	os::print("configuring BDX App\n");
-	config->load();
-	config->parse();
-	config->config();
+	cfg->load();
+	cfg->parse();
+	cfg->config();
 
 	Stack *stack = new Stack();
 	void *data = lmp::load();


### PR DESCRIPTION
if used before constructing config object the particles won't interact but that's not easy to do at the present moment because we import the particles data after constructing config; that's why runtime checks have not been added.

we have renamed `config` to `cfg` to avoid name collisions with the namespace `config`