### PR TITLE
Verlet list

### DIFF
--- a/include/Driver.h
+++ b/include/Driver.h
@@ -10,6 +10,7 @@ struct Driver
 	void bind(BDX *app);
 	void *operator new(size_t size);
 	void operator delete(void *p);
+	void buildVerletList();
 	void BrownianMotion();
 	void contain();
 };

--- a/include/List.h
+++ b/include/List.h
@@ -6,7 +6,7 @@ struct Particle;
 
 struct List
 {
-	Stack *stack = NULL;
+	Stack *__stack__ = NULL;
 	List(Stack *stack);
 	size_t cap() const;
 	size_t numel() const;

--- a/include/Particle.h
+++ b/include/Particle.h
@@ -42,6 +42,7 @@ struct Particle : BDXObject
 	void _translate_(double const mobility);
 	void _rotate_(double const mobility);
 	void _orient_(double const mobility);
+	void buildVerletList(Particle **begin, Particle **end);
 	void BrownianMotion();
 	void txt(void *stream) const;
 	double radius() const;

--- a/include/VerletList.h
+++ b/include/VerletList.h
@@ -1,0 +1,51 @@
+#ifndef GUARD_BDX_VERLET_LIST_H
+#define GUARD_BDX_VERLET_LIST_H
+
+struct List;
+struct Particle;
+
+struct VerletList
+{
+	double d = 0;
+	Vector *dr = NULL;
+	List *__list__ = NULL;
+	VerletList(List *list, Vector *displacement);
+	size_t cap() const;
+	size_t numel() const;
+	void add(Particle *particle);
+	void clear();
+	const Particle **begin() const;
+	const Particle **end() const;
+	void *operator new(size_t size);
+	void operator delete(void *p);
+};
+
+#endif
+
+/*
+
+BDX                                             December 31, 2023
+
+Copyright (C) 2023 Misael Díaz-Maldonado
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+author: @misael-diaz
+source: include/VerletList.h
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics.
+
+*/

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,6 +24,8 @@ handlers: particles
 	@$(MAKE) -C handler
 lists: particles
 	@$(MAKE) -C list
+verlet-lists: lists
+	@$(MAKE) -C VerletList
 utils:
 	@$(MAKE) -C util
 lmps:
@@ -74,6 +76,7 @@ BDX: boxes\
      handlers\
      PRNGs\
      lists\
+     verlet-lists\
      virtuals\
      configs\
      loopers\
@@ -97,6 +100,7 @@ clean:
 	@$(MAKE) -C stack clean
 	@$(MAKE) -C handler clean
 	@$(MAKE) -C list clean
+	@$(MAKE) -C VerletList clean
 	@$(MAKE) -C id clean
 	@$(MAKE) -C kind clean
 	@$(MAKE) -C vector clean

--- a/src/VerletList/Makefile
+++ b/src/VerletList/Makefile
@@ -1,0 +1,26 @@
+#!/usr/bin/make
+#
+# BDX						December 05, 2023
+#
+# source: src/VerletList/Makefile
+# author: @misael-diaz
+#
+# Synopsis:
+# Defines the Makefile for building the program with GNU make.
+#
+# Copyright (c) 2023 Misael Díaz-Maldonado
+# Copyright (c) 2024 UCF-Research Group
+# This file is released under the GNU General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+
+include make-inc
+
+all: $(VERLET_LIST_OBJ)
+
+$(VERLET_LIST_OBJ): $(HEADERS) $(VERLET_LIST_CXX)
+	$(CXX) $(INC) $(CXXOPT) -c $(VERLET_LIST_CXX) -o $(VERLET_LIST_OBJ)
+
+clean:
+	/bin/rm -f *.obj

--- a/src/VerletList/VerletList.cpp
+++ b/src/VerletList/VerletList.cpp
@@ -1,0 +1,79 @@
+#include "util.h"
+#include "List.h"
+#include "Particle.h"
+#include "VerletList.h"
+
+VerletList::VerletList (List *list, Vector *displacement) : d(0)
+{
+	this->__list__ = list;
+	this->dr = displacement;
+}
+
+size_t VerletList::cap () const
+{
+	return this->__list__->cap();
+}
+
+size_t VerletList::numel () const
+{
+	return this->__list__->numel();
+}
+
+void VerletList::clear ()
+{
+	this->__list__->clear();
+}
+
+const Particle **VerletList::begin () const
+{
+	return this->__list__->begin();
+}
+
+const Particle **VerletList::end () const
+{
+	return this->__list__->end();
+}
+
+void VerletList::add (Particle *particle)
+{
+	this->__list__->add(particle);
+}
+
+void *VerletList::operator new (size_t size)
+{
+	return util::malloc(size);
+}
+
+void VerletList::operator delete (void *p)
+{
+	p = util::free(p);
+}
+
+/*
+
+BDX                                             December 31, 2023
+
+Copyright (C) 2023 Misael Díaz-Maldonado
+Copyright (C) 2024 UCF-Research Group
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+author: @misael-diaz
+source: src/VerletList/VerletList.cpp
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics.
+
+*/

--- a/src/VerletList/make-inc
+++ b/src/VerletList/make-inc
@@ -1,0 +1,27 @@
+#
+# BDX						December 05, 2023
+#
+# source: src/list/make-inc
+# author: @misael-diaz
+#
+# Synopsis:
+# Defines the include file for building the program with GNU make.
+#
+# Copyright (c) 2023 Misael Díaz-Maldonado
+# Copyright (c) 2024 UCF-Research Group
+# This file is released under the GNU General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+
+INC = -I../../include
+
+UTIL_H     = ../../include/util.h
+LIST_H     = ../../include/List.h
+VECTOR_H = ../../include/Vector.h
+PARTICLE_H = ../../include/Particle.h
+VERLET_LIST_H = ../../include/VerletList.h
+HEADERS = $(UTIL_H) $(LIST_H) $(VECTOR_H) $(PARTICLE_H) $(VERLET_LIST_H)
+
+VERLET_LIST_CXX = VerletList.cpp
+VERLET_LIST_OBJ = VerletList.obj

--- a/src/driver/Driver.cpp
+++ b/src/driver/Driver.cpp
@@ -43,6 +43,15 @@ void Driver::contain ()
 	system->contain();
 }
 
+void Driver::buildVerletList ()
+{
+	Handler *h = this->app->system->handler;
+	for (Particle **particles = h->begin(); particles != h->end(); ++particles) {
+		Particle *p = *particles;
+		p->buildVerletList(h->begin(), h->end());
+	}
+}
+
 /*
 
 BDX                                             December 31, 2023

--- a/src/list/List.cpp
+++ b/src/list/List.cpp
@@ -6,38 +6,38 @@
 
 List::List (Stack *stack)
 {
-	this->stack = stack;
+	this->__stack__ = stack;
 }
 
 size_t List::cap () const
 {
-	return this->stack->cap();
+	return this->__stack__->cap();
 }
 
 size_t List::numel () const
 {
-	return this->stack->numel();
+	return this->__stack__->numel();
 }
 
 const Particle **List::begin () const
 {
-	return ((const Particle**) this->stack->begin());
+	return ((const Particle**) this->__stack__->begin());
 }
 
 const Particle **List::end () const
 {
-	return ((const Particle**) this->stack->end());
+	return ((const Particle**) this->__stack__->end());
 }
 
 void List::add (Particle *particle)
 {
 	void *elem = (void*) particle;
-	this->stack->add(elem);
+	this->__stack__->add(elem);
 }
 
 void List::clear ()
 {
-	this->stack->clear();
+	this->__stack__->clear();
 }
 
 void *List::operator new (size_t size)

--- a/src/looper/Looper.cpp
+++ b/src/looper/Looper.cpp
@@ -46,6 +46,7 @@ void Looper::loop ()
 		size_t istep = 0;
 		constexpr size_t isteps = (GLOBAL_TIME_STEP_LOGGER / GLOBAL_TIME_STEP);
 		while (istep != isteps) {
+			driver->buildVerletList();
 			driver->BrownianMotion();
 			driver->contain();
 			++istep;

--- a/src/particle/Particle.cpp
+++ b/src/particle/Particle.cpp
@@ -129,6 +129,17 @@ double Particle::radius () const
 	return this->__radius__;
 }
 
+void Particle::buildVerletList (Particle **begin, Particle **end)
+{
+	for (Particle **particles = begin; particles != end; ++particles) {
+		Particle *particle = *particles;
+		Particle *that = particle;
+		if (this == that) {
+			continue;
+		}
+	}
+}
+
 /*
 
 BDX                                             December 31, 2023


### PR DESCRIPTION
- prepares `struct List` to become the underlying data structure for `VerletList`
- adds `VerletList`
- adds initial `buildVerletList` member function

we still have to replace `List` with `VerletList` in the definition of `Particle` before we implement this

note that we keep track of the distance traveled for each particle so that we can determine if the list should be built again; we are keeping the needed data as part of the `VerletList` data structure for convenience

logging what has been achieved so far

particles are able to see themselves so that they won't add themselves to the list of neighbors (that's the only logic that was added to `buildVerletList`)

valgrind reports no memory issues
