### PR TITLE
drops `const` qualifier from `List` `VerletList`

### DIFF
--- a/include/List.h
+++ b/include/List.h
@@ -12,8 +12,8 @@ struct List
 	size_t numel() const;
 	void add(Particle *particle);
 	void clear();
-	const Particle **begin() const;
-	const Particle **end() const;
+	Particle **begin();
+	Particle **end();
 	void *operator new(size_t size);
 	void operator delete(void *p);
 };

--- a/include/VerletList.h
+++ b/include/VerletList.h
@@ -14,8 +14,8 @@ struct VerletList
 	size_t numel() const;
 	void add(Particle *particle);
 	void clear();
-	const Particle **begin() const;
-	const Particle **end() const;
+	Particle **begin();
+	Particle **end();
 	void *operator new(size_t size);
 	void operator delete(void *p);
 };

--- a/src/VerletList/VerletList.cpp
+++ b/src/VerletList/VerletList.cpp
@@ -24,12 +24,12 @@ void VerletList::clear ()
 	this->__list__->clear();
 }
 
-const Particle **VerletList::begin () const
+Particle **VerletList::begin ()
 {
 	return this->__list__->begin();
 }
 
-const Particle **VerletList::end () const
+Particle **VerletList::end ()
 {
 	return this->__list__->end();
 }

--- a/src/list/List.cpp
+++ b/src/list/List.cpp
@@ -19,14 +19,14 @@ size_t List::numel () const
 	return this->__stack__->numel();
 }
 
-const Particle **List::begin () const
+Particle **List::begin ()
 {
-	return ((const Particle**) this->__stack__->begin());
+	return ((Particle**) this->__stack__->begin());
 }
 
-const Particle **List::end () const
+Particle **List::end ()
 {
-	return ((const Particle**) this->__stack__->end());
+	return ((Particle**) this->__stack__->end());
 }
 
 void List::add (Particle *particle)


### PR DESCRIPTION
NOTES:
`const` qualifiers can be easily discarded so it's pointless to return a const pointer to the "world".