### PR TITLE
adds `Particle::contact()` to determine the contact-distance

### DIFF
--- a/include/Particle.h
+++ b/include/Particle.h
@@ -43,6 +43,7 @@ struct Particle : BDXObject
 	void _translate_(double const mobility);
 	void _rotate_(double const mobility);
 	void _orient_(double const mobility);
+	double contact(const Particle *particle) const;
 	void buildVerletList(Particle **begin, Particle **end);
 	void BrownianMotion();
 	void txt(void *stream) const;

--- a/src/particle/Particle.cpp
+++ b/src/particle/Particle.cpp
@@ -129,6 +129,12 @@ double Particle::radius () const
 	return this->__radius__;
 }
 
+double Particle::contact (const Particle *particle) const
+{
+	const Particle *that = particle;
+	return (this->radius() + that->radius());
+}
+
 void Particle::buildVerletList (Particle **begin, Particle **end)
 {
 	for (Particle **particles = begin; particles != end; ++particles) {


### PR DESCRIPTION
NOTES:
adds particle center-to-center computation, that is, the `contact` distance of the particles

note that for spheroids `_radius_` is initialized with the minor radius attribute

this is important for neighbor-list building
