### PR TITLE
implements simple `Particle::buildNeighborList()`

### DIFF
--- a/include/Particle.h
+++ b/include/Particle.h
@@ -44,7 +44,12 @@ struct Particle : BDXObject
 	void _rotate_(double const mobility);
 	void _orient_(double const mobility);
 	double contact(const Particle *particle) const;
+	double extent2(const Particle *particle) const;
+	bool isNeighbor(const Particle *particle) const;
+	void addNeighbor(Particle *particle);
+	size_t sizeVerletList() const;
 	void buildVerletList(Particle **begin, Particle **end);
+	void clearVerletList();
 	void BrownianMotion();
 	void txt(void *stream) const;
 	double radius() const;


### PR DESCRIPTION
NOTES:
- adds initial member function for building the neighbor-list
- we shall account for the system periodicity later!
- code passes neighbor-list test (neighbor-list size is equal to the number of interacting pairs)
- bear in mind that the extent of interaction is defined with respect to the contact distance
- valgrind reports no memory issues