### PR TITLE
checks interaction tables

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -20,6 +20,7 @@ struct Config
 	void load();
 	void parse();
 	void config();
+	void sane();
 	void *operator new(size_t size);
 	void operator delete(void *p);
 };

--- a/include/Particle.h
+++ b/include/Particle.h
@@ -43,6 +43,7 @@ struct Particle : BDXObject
 	void _translate_(double const mobility);
 	void _rotate_(double const mobility);
 	void _orient_(double const mobility);
+	bool checkInteractionTable(const Particle **begin, const Particle **end) const;
 	double contact(const Particle *particle) const;
 	double extent2(const Particle *particle) const;
 	bool isNeighbor(const Particle *particle) const;

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -8,6 +8,7 @@
 #include "Stack.h"
 #include "BDXObject.h"
 #include "BoundingBox.h"
+#include "Handler.h"
 #include "Particle.h"
 #include "Config.h"
 #include "System.h"
@@ -372,6 +373,29 @@ void Config::config ()
 			continue;
 		}
 	}
+}
+
+static void cfg_saneCheckInteractionTable (const System *sys)
+{
+	Handler *h = sys->handler;
+	Particle **begin = h->begin();
+	Particle **end = h->end();
+	for (Particle **particles = begin; particles != end; ++particles) {
+		const Particle *particle = *particles;
+		const Particle **begin_const = (const Particle**) begin;
+		const Particle **end_const = (const Particle**) end;
+		bool const sane = particle->checkInteractionTable(begin_const, end_const);
+		if (!sane) {
+			os::error("Config::sane: InteractionTableError\n");
+			util::quit();
+		}
+	}
+}
+
+void Config::sane ()
+{
+	const System *sys = this->app->system;
+	cfg_saneCheckInteractionTable(sys);
 }
 
 double config::particleInteractionRange(const Particle *p1, const Particle *p2)

--- a/src/particle/Particle.cpp
+++ b/src/particle/Particle.cpp
@@ -134,6 +134,27 @@ double Particle::radius () const
 	return this->__radius__;
 }
 
+// NOTE:
+// if the user forgets to adds the interaction ranges (for the particle kinds of interest)
+// to these tables we will be able to determine that and complain accordingly as long as
+// these tables remain static (zero initialized) in the `config` module
+bool Particle::checkInteractionTable (const Particle **begin, const Particle **end) const
+{
+	for (const Particle **particles = begin; particles != end; ++particles) {
+		const Particle *particle = *particles;
+		const Particle *that = particle;
+		if (that == this) {
+			continue;
+		}
+		double const tbl = config::particleInteractionRange(this, that);
+		double const xtbl = config::particleExtendedInteractionRange(this, that);
+		if (tbl == 0 || xtbl == 0) {
+			return false;
+		}
+	}
+	return true;
+}
+
 double Particle::contact (const Particle *particle) const
 {
 	const Particle *that = particle;

--- a/src/test/util/test.cpp
+++ b/src/test/util/test.cpp
@@ -662,7 +662,7 @@ void tutil16 (void)
 	cfg->load();
 	cfg->parse();
 	cfg->config();
-	App->_exec_ = true;
+	App->_exec_ = false;
 	App->looper->loop();
 	util::clearall();
 }
@@ -798,7 +798,7 @@ void tutil19 (void)
 		it += 3; // skips optional director (of zeros)
 	}
 
-	App->_exec_ = true;
+	App->_exec_ = false;
 	App->looper->loop();
 	util::clearall();
 }
@@ -817,6 +817,7 @@ void tutil20 (void)
 
 void tutil21(void)
 - imports LAMMPS spheres data
+- performs sane checks (verifies that the particle interaction-range tables have been set)
 - performs a 15 minute simulation test run
 - checks that no particle is outside the system boundaries when the BDX simulation ends
 - dumps the particle and simulation data to plain text file
@@ -889,6 +890,8 @@ void tutil21 (void)
 		it += 3; // skips optional director (of zeros)
 	}
 
+	os::print("performing sane-checks\n");
+	cfg->sane();
 	os::print("executing BDX test-run\n");
 	App->_exec_ = true;
 	App->looper->loop();


### PR DESCRIPTION
NOTES:
checks that the interaction tables have been set for the particle kinds of interest, we expect this check to be passed since we only have spheres and these tables are set by default for spheres

passes sane-check

disables execution of BDX for other tests

valgrind reports no memory issues