### PR TITLE
adds min contact-distance computation

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -20,6 +20,8 @@ struct Config
 	void load();
 	void parse();
 	void config();
+	void _late_config_minContactDistance_();
+	void late_config();
 	void sane();
 	void *operator new(size_t size);
 	void operator delete(void *p);

--- a/include/Particle.h
+++ b/include/Particle.h
@@ -22,6 +22,7 @@ struct Particle : BDXObject
 	double __radius__ = 1.0;
 	double __translational_mobility_scaling__ = 1.0;
 	double __rotational_mobility_scaling__ = 1.0;
+	double __contact_distance_min__ = (2.0 * __radius__);
 	Particle(Vector *r,
 		 Vector *u,
 		 Vector *E,
@@ -45,6 +46,9 @@ struct Particle : BDXObject
 	void _orient_(double const mobility);
 	bool checkInteractionTable(const Particle **begin, const Particle **end) const;
 	double contact(const Particle *particle) const;
+	void minContactDistance(const Particle **begin, const Particle **end);
+	double getMinContactDistance() const;
+	void setMinContactDistance(double const);
 	double extent2(const Particle *particle) const;
 	bool isNeighbor(const Particle *particle) const;
 	void addNeighbor(Particle *particle);

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <cstring>
 #include <cstdlib>
 #include <cstdio>
@@ -373,6 +374,38 @@ void Config::config ()
 			continue;
 		}
 	}
+}
+
+void Config::_late_config_minContactDistance_ ()
+{
+	System *sys = this->app->system;
+	Handler *h = sys->handler;
+	Particle **begin = h->begin();
+	Particle **end = h->end();
+	const Particle **begin_const = (const Particle**) begin;
+	const Particle **end_const = (const Particle**) end;
+	for (Particle **particles = begin; particles != end; ++particles) {
+		Particle *particle = *particles;
+		particle->minContactDistance(begin_const, end_const);
+	}
+
+	double minContactDistance = INFINITY;
+	for (const Particle **parts = begin_const; parts != end_const; ++parts) {
+		const Particle *particle = *parts;
+		if (particle->getMinContactDistance() < minContactDistance) {
+			minContactDistance = particle->getMinContactDistance();
+		}
+	}
+
+	for (Particle **particles = begin; particles != end; ++particles) {
+		Particle *particle = *particles;
+		particle->setMinContactDistance(minContactDistance);
+	}
+}
+
+void Config::late_config ()
+{
+	this->_late_config_minContactDistance_();
 }
 
 static void cfg_saneCheckInteractionTable (const System *sys)

--- a/src/particle/Particle.cpp
+++ b/src/particle/Particle.cpp
@@ -35,6 +35,7 @@ Particle::Particle (Vector *r,
 	this->__radius__ = a;
 	this->__rotational_mobility_scaling__= (1.0 / sqrt(a * a * a));
 	this->__translational_mobility_scaling__ = (1.0 / sqrt(a));
+	this->__contact_distance_min__ = (2.0 * a);
 }
 
 void *Particle::operator new (size_t size)
@@ -113,6 +114,33 @@ void Particle::BrownianMotion ()
 	this->_translate_(translational_mobility);
 	this->_rotate_(rotational_mobility);
 	this->_orient_(rotational_mobility);
+}
+
+void Particle::minContactDistance (const Particle **begin, const Particle **end)
+{
+	double min = INFINITY;
+	for (const Particle **particles = begin; particles != end; ++particles) {
+		const Particle *particle = *particles;
+		const Particle *that = particle;
+		if (that == this) {
+			continue;
+		}
+		double const contact = this->contact(that);
+		if (contact < min) {
+			min = contact;
+		}
+	}
+	this->__contact_distance_min__ = min;
+}
+
+double Particle::getMinContactDistance () const
+{
+	return this->__contact_distance_min__;
+}
+
+void Particle::setMinContactDistance (double const contact_distance_min)
+{
+	this->__contact_distance_min__ = contact_distance_min;
 }
 
 void Particle::txt (void *stream) const


### PR DESCRIPTION
NOTES:
we need to know the minimum contact distance to obtain the (extended) interaction ranges for building the Verlet-list

this seems kind of overkill because we have uniformly-sized spheres but this code should work for other size distributions

we don't mind rolling out an algorithm that runs quadratically because this only happens during configuration of the BDX App

test passed for a uniformly sized suspension

valgrind reports no memory issues